### PR TITLE
NXP-30583: fix error on unit tests namespace

### DIFF
--- a/ci/helm/utests/nuxeo-test-base-values.yaml
+++ b/ci/helm/utests/nuxeo-test-base-values.yaml
@@ -3,13 +3,13 @@ nuxeo:
 redis:
   master:
     podLabels:
-      branch: $BRANCH_NAME
+      branch: $BRANCH_LC
       resource: pod
       team: napps
       usage: utests
     service:
       labels:
-        branch: $BRANCH_NAME
+        branch: $BRANCH_LC
         resource: service
         team: napps
         usage: utests

--- a/ci/helm/utests/nuxeo-test-mongodb-values.yaml
+++ b/ci/helm/utests/nuxeo-test-mongodb-values.yaml
@@ -1,11 +1,11 @@
 mongodb:
   labels:
-    branch: $BRANCH_NAME
+    branch: $BRANCH_LC
     resource: deployment
     team: napps
     usage: utests
   podLabels:
-    branch: $BRANCH_NAME
+    branch: $BRANCH_LC
     resource: pod
     team: napps
     usage: utests
@@ -25,4 +25,3 @@ mongodb:
       memory: 500Mi
 tags:
   mongodb: true
-

--- a/ci/helm/utests/nuxeo-test-pgsql-values.yaml
+++ b/ci/helm/utests/nuxeo-test-pgsql-values.yaml
@@ -1,12 +1,12 @@
 postgresql:
   podLabels:
-    branch: $BRANCH_NAME
+    branch: $BRANCH_LC
     resource: pod
     team: napps
     usage: utests
   master:
     labels:
-      branch: "$BRANCH_NAME"
+      branch: "$BRANCH_LC"
       resource: deployment
       team: napps
       usage: utests


### PR DESCRIPTION
```
[2021-09-29T12:22:19.182Z] [unable to decode "/tmp/helm-template-workdir-250547384/test-release/output/namespaces/nuxeo-coldstorage-10-10-mongodb/nuxeo/charts/mongodb/templates/part0-deployment-standalone.yaml": resource.metadataOnlyObject.ObjectMeta: v1.ObjectMeta.Labels: ReadString: expects " or n, but found 1, error found in #10 byte of ...|"branch":10.1,"chart|..., bigger context ...|art":"nuxeo"},"labels":{"app":"mongodb","branch":10.1,"chart":"mongodb-7.14.8","heritage":"Tiller","|..., unable to decode "/tmp/helm-template-workdir-250547384/test-release/output/namespaces/nuxeo-coldstorage-10-10-mongodb/nuxeo/charts/redis/templates/part0-redis-master-svc.yaml": resource.metadataOnlyObject.ObjectMeta: v1.ObjectMeta.Labels: ReadString: expects " or n, but found 1, error found in #10 byte of ...|"branch":10.1,"chart|..., bigger context ...|chart":"nuxeo"},"labels":{"app":"redis","branch":10.1,"chart":"redis-11.2.3","heritage":"Tiller","je|...]

[2021-09-29T12:22:19.182Z] Error from server (BadRequest): error when creating "/tmp/helm-template-workdir-250547384/test-release/output/namespaces/nuxeo-coldstorage-10-10-mongodb/nuxeo/charts/redis/templates/part0-redis-master-statefulset.yaml": StatefulSet in version "v1" cannot be handled as a StatefulSet: v1.StatefulSet.Spec: v1.StatefulSetSpec.Template: v1.PodTemplateSpec.ObjectMeta: v1.ObjectMeta.Labels: ReadString: expects " or n, but found 1, error found in #10 byte of ...|"branch":10.1,"chart|..., bigger context ...|5991b7852b855"},"labels":{"app":"redis","branch":10.1,"chart":"redis-11.2.3","release":"test-release|...'
```