### PR TITLE
task-NXP-32301-use-the-NotificationFeature-in-tests

### DIFF
--- a/nuxeo-coldstorage/pom.xml
+++ b/nuxeo-coldstorage/pom.xml
@@ -98,6 +98,12 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.nuxeo.ecm.platform</groupId>
+      <artifactId>nuxeo-platform-notification</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/ColdStorageFeature.java
+++ b/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/ColdStorageFeature.java
@@ -19,6 +19,7 @@
 
 package org.nuxeo.coldstorage;
 
+import org.nuxeo.ecm.platform.ec.notification.NotificationFeature;
 import org.nuxeo.ecm.platform.picture.core.ImagingFeature;
 import org.nuxeo.runtime.test.runner.Deploy;
 import org.nuxeo.runtime.test.runner.Features;
@@ -28,7 +29,7 @@ import org.nuxeo.runtime.test.runner.RunnerFeature;
 /**
  * @since 2021.0.0
  */
-@Features({ImagingFeature.class, LogCaptureFeature.class})
+@Features({ ImagingFeature.class, LogCaptureFeature.class, NotificationFeature.class })
 @Deploy("org.nuxeo.ecm.platform.notification")
 @Deploy("org.nuxeo.ecm.core.management")
 @Deploy("org.nuxeo.ecm.platform.video")

--- a/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/operations/TestColdStorageRendition.java
+++ b/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/operations/TestColdStorageRendition.java
@@ -53,7 +53,7 @@ import org.nuxeo.runtime.test.runner.Features;
 /**
  * @since 2021.0.0
  */
-@Features({ ColdStorageFeature.class, S3BlobProviderFeature.class})
+@Features({ ColdStorageFeature.class, S3BlobProviderFeature.class })
 public class TestColdStorageRendition extends AbstractTestColdStorageOperation {
 
     @Inject
@@ -149,6 +149,7 @@ public class TestColdStorageRendition extends AbstractTestColdStorageOperation {
         session.save();
         return document;
     }
+
     @Override
     protected void checkMoveContent(List<DocumentModel> expectedDocs, List<DocumentModel> actualDocs) {
         assertEquals(expectedDocs.size(), actualDocs.size());


### PR DESCRIPTION
At first I added the `NotificationFeature` repeatedly but tests using the `DummyColdStorageFeature` always benefit from the `NotificationFeature` so I included the notif in the dummy feature.