### PR TITLE
NXP-32100: Add migration to restore all documents from cold storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,167 @@
+# Nuxeo Cold Storage - Agent Development Guide
+
+## Project Overview
+
+**Nuxeo Cold Storage** is a Nuxeo addon that enables cold storage of document main content for archiving, compliance, and cost optimization. This is a Maven multi-module Java project hosted at `github.com/nuxeo/nuxeo-coldstorage` on branch `lts-2025`.
+
+The addon extends Nuxeo Platform and provides both backend (Java) and frontend (Web Components) contributions, packaged as a Nuxeo Marketplace package.
+
+### Module Hierarchy
+
+```
+nuxeo-coldstorage-parent (root)
+├── nuxeo-coldstorage/         # Backend: Core addon module with services, operations, events, actions
+├── nuxeo-coldstorage-web/     # Frontend: Web Components for Nuxeo Web UI integration
+├── nuxeo-coldstorage-package/ # Marketplace package builder (produces .zip)
+└── ci/                        # Jenkins pipelines, Helm charts, CI scripts
+```
+
+### POM Hierarchy
+
+```
+nuxeo-coldstorage-parent (root, org.nuxeo.coldstorage)   # Parent POM, dependency management
+├── Parent: nuxeo-parent (org.nuxeo)                     # Inherits from Nuxeo's re-exportable parent
+└── Modules:
+      ├── nuxeo-coldstorage                              # Core addon (JAR)
+      ├── nuxeo-coldstorage-web                          # Web UI contributions (JAR with ES modules)
+      └── nuxeo-coldstorage-package                      # Marketplace package (ZIP)
+```
+
+The root POM manages **internal module versions** only (`nuxeo-coldstorage`, `nuxeo-coldstorage-web`, `nuxeo-coldstorage-package`). **All Nuxeo dependencies** (runtime, core, platform) are inherited **without `<version>` tags** from `nuxeo-parent` and its transitive BOM.
+
+### Build System
+
+- **Maven** multi-module, inheriting from `nuxeo-parent`
+- **Java 21** with `<release>21</release>` (inherited from nuxeo-parent)
+- **Maven 3.6.3+** required
+- **Node.js v22.17.0** required for web module
+- Default build: `mvn clean install`
+- Skip tests: `mvn clean install -DskipTests`
+- Code formatting: `mvn spotless:check` / `mvn spotless:apply` (Eclipse formatter, ratcheted from `origin/lts-2025`)
+- NPM registry configuration required in `$HOME/.npmrc`:
+  ```
+  @nuxeo:registry=https://packages.nuxeo.com/repository/npm-public/
+  ```
+
+**Maven Build Tips**:
+- Use `-nsu` (or `--no-snapshot-updates`) to suppress SNAPSHOT dependency checks for faster repeated builds:
+  ```bash
+  mvn test -pl nuxeo-coldstorage -nsu
+  ```
+- Combine with `-ntp` (no transfer progress) for cleaner output:
+  ```bash
+  mvn test -pl nuxeo-coldstorage -nsu -ntp
+  ```
+- For single test execution:
+  ```bash
+  mvn test -Dtest=MoveToColdStorageTest -pl nuxeo-coldstorage -nsu
+  ```
+
+---
+
+## Nuxeo Platform Development Conventions
+
+This addon follows standard Nuxeo Platform development conventions. For comprehensive guidance on:
+
+- Java conventions and modern Java features
+- Component model and dependency injection
+- Configuration, persistence, and document model APIs
+- REST API, JSON marshalling, and async work patterns
+- Testing framework and patterns
+- Third-party libraries and Git conventions
+
+**See the [Nuxeo Platform Agent Development Guide](https://github.com/nuxeo/nuxeo/blob/lts-2025/AGENTS.md)**
+
+---
+
+## Cold Storage Addon Architecture
+
+### Core Components
+
+The Cold Storage addon is organized in the `org.nuxeo.coldstorage` package with the following key components:
+
+**Service Layer** (`org.nuxeo.coldstorage.service`):
+- `ColdStorageService`: Main service interface for cold storage operations
+- `ColdStorageServiceImpl`: Component implementation providing the service
+
+**Bulk Actions** (`org.nuxeo.coldstorage.action`):
+- `MoveToColdStorageContentAction`: Moves document main content to cold storage
+- `PropagateMoveToColdStorageContentAction`: Propagates move operation to related documents
+- `CheckColdStorageAvailabilityAction`: Checks retrieval status via scheduled execution
+- `PropagateRestoreFromColdStorageContentAction`: Propagates restore operation to related documents
+
+**Operations** (`org.nuxeo.coldstorage.operations`):
+- Automation operations exposed via REST API for cold storage actions
+
+**Event Listeners** (`org.nuxeo.coldstorage.events`):
+- Event handlers for document lifecycle and content changes
+
+**JSON Marshalling** (`org.nuxeo.coldstorage.io`):
+- JSON enrichers for cold storage metadata
+
+### Schema
+
+The addon contributes a `coldstorage` schema (XSD at `schemas/coldstorage.xsd`) with fields including:
+- `coldContent`: Reference to the archived blob in cold storage
+- `beingRetrieved`: Flag indicating retrieval in progress
+- Additional metadata for tracking cold storage state
+
+### Extension Points
+
+**`coldStorageRendition`** (contributed by `ColdStorageService`):
+Configures which rendition to use as a placeholder when content is moved to cold storage. Can be configured by document type or facet:
+
+```xml
+<extension target="org.nuxeo.coldstorage.service.ColdStorageService" point="coldStorageRendition">
+  <coldStorageRendition name="defaultRendition" renditionName="Thumbnail" />
+  <coldStorageRendition name="pictureRendition" docType="Picture" facet="Picture" renditionName="Small" />
+</extension>
+```
+
+### Migrations
+
+#### Cold Storage Restore Migration
+
+**ID**: `restore-from-cold-storage-migration`
+**Since**: 2025.2
+**Purpose**: Automatically restores documents from cold storage when the `nuxeo.coldstorage.migration.restore.enabled` property is enabled.
+
+**States**:
+- `disabled`: Move to cold storage is not blocked (default state)
+- `enabled`: Move to cold storage is blocked, and there are documents in cold storage that need restoration
+- `done`: All documents have been restored from cold storage (no documents remaining with non-downloadable blobs)
+
+**Migration Step**: `enabled-to-done`
+
+**Behavior**:
+1. When `nuxeo.coldstorage.migration.restore.enabled` is set to `true`, the migration automatically probes for its state
+2. The migration queries for all documents with the ColdStorage facet (mixinType)
+3. If documents with the ColdStorage facet exist, the state becomes `enabled`
+4. Running the migration step processes all documents with the ColdStorage facet and attempts to restore them
+5. The migrator assumes all blobs are downloadable and attempts restoration
+6. If a blob is not downloadable (e.g., still in GLACIER storage class), the migrator:
+   - Logs a **WARNING** message indicating the document cannot be restored
+   - Skips the document (document keeps its ColdStorage facet) and continues processing
+7. After migration completes, the migration probes again:
+   - If ALL documents were successfully restored (no documents with ColdStorage facet remain) → state transitions to `done`
+   - If ANY documents still have the ColdStorage facet (not downloadable) → state remains `enabled`
+8. The migration uses the bulk action framework to restore documents in batches
+
+**Usage**:
+```bash
+# Check migration status
+curl -u Administrator:Administrator \
+  http://localhost:8080/nuxeo/site/management/migration/restore-from-cold-storage-migration
+
+# Run the migration (if in 'enabled' state)
+curl -u Administrator:Administrator -X POST \
+  http://localhost:8080/nuxeo/site/management/migration/restore-from-cold-storage-migration/enabled-to-done
+```
+
+**Implementation**: `org.nuxeo.coldstorage.migrator.RestoreFromColdStorageMigrator`
+
+---
+
+## Configuration and Deployment
+
+For configuration properties, database indexes, and operational procedures (including exiting cold storage), see the [README](README.md).

--- a/README.md
+++ b/README.md
@@ -68,6 +68,76 @@ Create the following db indexes for an optimal functioning of the addon:
  - `nuxeo.bulk.action.checkColdStorageAvailability.scroller` : scroller implementation to be used to query documents being retrieved. `elastic` value can be set to relieve the regular back-end.
  - `nuxeo.coldstorage.numberOfDaysOfAvailability.value.default` : number of days a document remains available once it has been retrieved. Default value is `1`.
  - `nuxeo.coldstorage.thumbnailPreviewRequired` : is a thumbnail required to be used as a place holder to send a document to Cold Storage. Default value is `true`.
+ - `nuxeo.coldstorage.migration.restore.enabled` : when set to `true`, exits the cold storage addon by restoring all documents and blocking move to cold storage operations. Default value is `false`. **@since 2025.2**
+
+    **Exiting Cold Storage**
+
+   This planned operation restores all documents from cold storage back to Nuxeo's default S3 storage class (typically Intelligent-Tiering). After completion, the cold storage addon can be uninstalled.
+
+   **Timeline:**
+   - S3 Bulk restore: ~12 hours
+   - Migration runtime: varies with document volume
+   - Recommended restore window: 30 days (maximum flexibility for retries)
+
+   **Impact:** Move to cold storage operations are immediately blocked when the property is enabled. Restore operations continue to work.
+
+   ---
+
+   **Step 1: Block New Moves to Cold Storage**
+
+   Enable the property to block move operations:
+   ```
+   nuxeo.coldstorage.migration.restore.enabled=true
+   ```
+   on all Nuxeo nodes (front and worker nodes) and proceed to a whole cluster restart. No new documents can be moved to cold storage. Restore operations continue to work.
+
+   **Note:** Any pending move to cold storage bulk actions already queued will complete with errors (documents skipped). This is expected and safe.
+
+   **Step 2: Restore S3 Objects**
+
+   Use S3 Batch Operations to restore all Glacier objects:
+   1. In AWS Console: **S3 > Batch Operations**
+   2. Create an S3 inventory for your bucket
+   3. Create a Batch Operations job: **Restore** operation
+   4. Use the inventory as source
+   5. Configure:
+      - Retrieval tier: **Bulk**
+      - Duration: **30 days** (or longer for maximum comfort)
+   6. Submit and monitor the job
+
+   **Step 3: Wait for Completion**
+
+   Monitor the Batch Operations job until all objects reach "Restored" state (typically 5-12 hours).
+
+   **Step 4: Run Migration**
+
+   Execute the Nuxeo migration to restore documents:
+   ```
+   # Check current status
+   GET  /nuxeo/site/management/migration/restore-from-cold-storage-migration
+
+   # Run the migration step
+   POST /nuxeo/site/management/migration/restore-from-cold-storage-migration/enabled-to-done
+
+   # Poll until migration is no longer running (step field is null)
+   GET  /nuxeo/site/management/migration/restore-from-cold-storage-migration
+
+   # Probe to refresh state after migration completes
+   POST /nuxeo/site/management/migration/restore-from-cold-storage-migration/probe
+   ```
+
+   After probing, check the state:
+   - **State `done`**: All documents restored successfully
+   - **State `enabled`**: Some documents remain in cold storage (blobs not yet downloadable from S3)
+
+   If state remains `enabled`, wait for S3 restore window and retry the migration step.
+
+   **Step 5: Cleanup**
+
+   Once migration status is `done`:
+   - All documents are restored in Nuxeo
+   - Content is stored at the default S3 storage class
+   - Uninstall the cold storage addon
 
 ### Frontend Contribution
 
@@ -121,7 +191,6 @@ npm run ftest
 ```
 
 To run the functional tests, [Nuxeo Web UI Functional Testing Framework](https://github.com/nuxeo/nuxeo-web-ui/tree/maintenance-3.0.x/packages/nuxeo-web-ui-ftest) is used.
-Due to its inner dependencies, it only works using NodeJS `lts/dubnium`, i.e., `v10`.
 
 ## Development Workflow
 
@@ -129,7 +198,7 @@ Due to its inner dependencies, it only works using NodeJS `lts/dubnium`, i.e., `
 
 *Disclaimer:* In order to contribute and develop Nuxeo Cold Storage UI, it is assumed that there is a Nuxeo server running with Nuxeo Cold Storage package installed and properly configured according the documentation above.
 
-#### Install Dependencies  
+#### Install Dependencies
 
 ```sh
 npm install

--- a/nuxeo-coldstorage-web/elements/nuxeo-move-content-to-coldstorage-button.js
+++ b/nuxeo-coldstorage-web/elements/nuxeo-move-content-to-coldstorage-button.js
@@ -98,7 +98,18 @@ class MoveToColdStorage extends mixinBehaviors([FiltersBehavior, FormatBehavior]
       !this.hasFacet(document, 'ColdStorage') &&
       (this.hasAdministrationPermissions(currentUser) || this.hasPermission(document, 'WriteColdStorage')) &&
       this.hasContent(document) &&
-      this._isRenditionAvailable(document)
+      this._isRenditionAvailable(document) &&
+      !this._isMoveToColdStorageBlocked()
+    );
+  }
+
+  _isMoveToColdStorageBlocked() {
+    return (
+      Nuxeo &&
+      Nuxeo.UI &&
+      Nuxeo.UI.config &&
+      Nuxeo.UI.config.coldstorage &&
+      Nuxeo.UI.config.coldstorage.restoreMigrationEnabled === 'true'
     );
   }
 

--- a/nuxeo-coldstorage-web/elements/nuxeo-move-contents-to-coldstorage-button.js
+++ b/nuxeo-coldstorage-web/elements/nuxeo-move-contents-to-coldstorage-button.js
@@ -105,7 +105,21 @@ class BulkMoveToColdStorage extends mixinBehaviors([FiltersBehavior, FormatBehav
   }
 
   _isAvailable(documents) {
-    return documents.length > 0 && documents.every((doc) => this._canMoveDocument(doc));
+    return (
+      !this._isMoveToColdStorageBlocked() &&
+      documents.length > 0 &&
+      documents.every((doc) => this._canMoveDocument(doc))
+    );
+  }
+
+  _isMoveToColdStorageBlocked() {
+    return (
+      Nuxeo &&
+      Nuxeo.UI &&
+      Nuxeo.UI.config &&
+      Nuxeo.UI.config.coldstorage &&
+      Nuxeo.UI.config.coldstorage.restoreMigrationEnabled === 'true'
+    );
   }
 
   _toggle() {

--- a/nuxeo-coldstorage-web/src/main/resources/META-INF/MANIFEST.MF
+++ b/nuxeo-coldstorage-web/src/main/resources/META-INF/MANIFEST.MF
@@ -6,3 +6,4 @@ Bundle-Version: 1.0.0
 Bundle-Name: nuxeo-coldstorage-web
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: nuxeo-coldstorage-web;singleton=true
+Nuxeo-Component: OSGI-INF/coldstorage-ui-properties-contrib.xml

--- a/nuxeo-coldstorage-web/src/main/resources/OSGI-INF/coldstorage-ui-properties-contrib.xml
+++ b/nuxeo-coldstorage-web/src/main/resources/OSGI-INF/coldstorage-ui-properties-contrib.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<component name="org.nuxeo.coldstorage.ui.properties">
+
+  <extension target="org.nuxeo.runtime.ConfigurationService" point="configuration">
+    <property name="org.nuxeo.web.ui.coldstorage.restoreMigrationEnabled">
+      ${nuxeo.coldstorage.migration.restore.enabled:=false}
+    </property>
+  </extension>
+
+</component>

--- a/nuxeo-coldstorage-web/test/elements/nuxeo-move-content-to-coldstorage-button.test.js
+++ b/nuxeo-coldstorage-web/test/elements/nuxeo-move-content-to-coldstorage-button.test.js
@@ -189,6 +189,50 @@ suite('Cold Storage', () => {
         await flush();
         expect(isElementVisible(button)).to.be.true;
       });
+
+      test('Should not be visible when restore migration is enabled', async () => {
+        window.Nuxeo = window.Nuxeo || {};
+        window.Nuxeo.UI = window.Nuxeo.UI || {};
+        window.Nuxeo.UI.config = {
+          coldstorage: {
+            restoreMigrationEnabled: 'true',
+          },
+        };
+
+        button = await fixture(
+          html`
+            <nuxeo-move-content-to-coldstorage-button .document=${document}></nuxeo-move-content-to-coldstorage-button>
+          `,
+        );
+
+        await flush();
+        expect(isElementVisible(button)).to.be.false;
+
+        // Cleanup
+        delete window.Nuxeo.UI.config.coldstorage;
+      });
+
+      test('Should be visible when restore migration is disabled', async () => {
+        window.Nuxeo = window.Nuxeo || {};
+        window.Nuxeo.UI = window.Nuxeo.UI || {};
+        window.Nuxeo.UI.config = {
+          coldstorage: {
+            restoreMigrationEnabled: 'false',
+          },
+        };
+
+        button = await fixture(
+          html`
+            <nuxeo-move-content-to-coldstorage-button .document=${document}></nuxeo-move-content-to-coldstorage-button>
+          `,
+        );
+
+        await flush();
+        expect(isElementVisible(button)).to.be.true;
+
+        // Cleanup
+        delete window.Nuxeo.UI.config.coldstorage;
+      });
     });
 
     suite('Interactions', () => {

--- a/nuxeo-coldstorage-web/test/elements/nuxeo-move-contents-to-coldstorage-button.test.js
+++ b/nuxeo-coldstorage-web/test/elements/nuxeo-move-contents-to-coldstorage-button.test.js
@@ -242,6 +242,54 @@ suite('Cold Storage', () => {
         await flush();
         expect(isElementVisible(button)).to.be.true;
       });
+
+      test('Should not be visible when restore migration is enabled', async () => {
+        window.Nuxeo = window.Nuxeo || {};
+        window.Nuxeo.UI = window.Nuxeo.UI || {};
+        window.Nuxeo.UI.config = {
+          coldstorage: {
+            restoreMigrationEnabled: 'true',
+          },
+        };
+
+        button = await fixture(
+          html`
+            <nuxeo-move-contents-to-coldstorage-button
+              .documents=${documents}
+            ></nuxeo-move-contents-to-coldstorage-button>
+          `,
+        );
+
+        await flush();
+        expect(isElementVisible(button)).to.be.false;
+
+        // Cleanup
+        delete window.Nuxeo.UI.config.coldstorage;
+      });
+
+      test('Should be visible when restore migration is disabled', async () => {
+        window.Nuxeo = window.Nuxeo || {};
+        window.Nuxeo.UI = window.Nuxeo.UI || {};
+        window.Nuxeo.UI.config = {
+          coldstorage: {
+            restoreMigrationEnabled: 'false',
+          },
+        };
+
+        button = await fixture(
+          html`
+            <nuxeo-move-contents-to-coldstorage-button
+              .documents=${documents}
+            ></nuxeo-move-contents-to-coldstorage-button>
+          `,
+        );
+
+        await flush();
+        expect(isElementVisible(button)).to.be.true;
+
+        // Cleanup
+        delete window.Nuxeo.UI.config.coldstorage;
+      });
     });
 
     suite('Interactions', () => {

--- a/nuxeo-coldstorage/pom.xml
+++ b/nuxeo-coldstorage/pom.xml
@@ -47,6 +47,14 @@
       <groupId>org.nuxeo.ecm.platform</groupId>
       <artifactId>nuxeo-platform-rendition-api</artifactId>
     </dependency>
+
+    <!-- Test libraries -->
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+    </dependency>
+
+    <!-- Nuxeo test libraries -->
     <dependency>
       <groupId>org.nuxeo.ecm.automation</groupId>
       <artifactId>nuxeo-automation-test</artifactId>

--- a/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/ColdStorageConstants.java
+++ b/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/ColdStorageConstants.java
@@ -72,7 +72,10 @@ public class ColdStorageConstants {
 
     /**
      * Status about the cold storage content being retrieved or available.
+     *
+     * @deprecated since 2025.2, unused
      */
+    @Deprecated(since = "2025.2", forRemoval = true)
     public static class ColdStorageContentStatus {
 
         protected final int totalBeingRetrieved;

--- a/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/ColdStorageConstants.java
+++ b/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/ColdStorageConstants.java
@@ -64,6 +64,11 @@ public class ColdStorageConstants {
 
     public static final String COLD_STORAGE_THUMBNAIL_PREVIEW_REQUIRED_PROPERTY_NAME = "nuxeo.coldstorage.thumbnailPreviewRequired";
 
+    /**
+     * @since 2025.2
+     */
+    public static final String COLD_STORAGE_RESTORE_MIGRATION_ENABLED_PROPERTY_NAME = "nuxeo.coldstorage.migration.restore.enabled";
+
     public static final String COLD_STORAGE_CONTENT_DOWNLOADABLE_UNTIL = "coldstorage:downloadableUntil";
 
     public static final String EVENT_CATEGORY = "coldStorage";

--- a/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/ColdStorageHelper.java
+++ b/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/ColdStorageHelper.java
@@ -22,10 +22,11 @@ import static org.nuxeo.coldstorage.ColdStorageConstants.COLD_STORAGE_CONTENT_PR
 
 import java.io.IOException;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import jakarta.annotation.Nonnull;
+
 import org.nuxeo.ecm.core.api.Blob;
 import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.NuxeoException;
 import org.nuxeo.ecm.core.blob.BlobManager;
 import org.nuxeo.ecm.core.blob.BlobProvider;
 import org.nuxeo.ecm.core.blob.BlobStatus;
@@ -39,32 +40,33 @@ import software.amazon.awssdk.services.s3.model.StorageClass;
  */
 public class ColdStorageHelper {
 
-    private static final Logger log = LogManager.getLogger(ColdStorageHelper.class);
-
-    public static BlobStatus getBlobStatus(DocumentModel doc) {
+    public static BlobStatus getBlobStatus(@Nonnull DocumentModel doc) {
         Blob coldContent = (Blob) doc.getPropertyValue(COLD_STORAGE_CONTENT_PROPERTY);
+        if (coldContent == null) {
+            throw new NuxeoException("Document: %s has no cold storage content.".formatted(doc.getId()));
+        }
         return getStatus((ManagedBlob) coldContent);
     }
 
-    public static BlobStatus getStatus(ManagedBlob blob) {
+    public static BlobStatus getStatus(@Nonnull ManagedBlob blob) {
         try {
             BlobProvider provider = Framework.getService(BlobManager.class).getBlobProvider(blob);
             return provider.getStatus(blob);
         } catch (IOException e) {
-            log.error("Unable to get blob status for blob: {}", blob, e);
-            return null;
+            throw new NuxeoException("Unable to get blob status for blob: %s".formatted(blob), e);
         }
     }
 
-    public static boolean isDownloadable(BlobStatus blobStatus) {
+    public static boolean isDownloadable(@Nonnull BlobStatus blobStatus) {
         return !isInColdStorage(blobStatus) || blobStatus.isDownloadable();
     }
 
-    public static boolean isInColdStorage(ManagedBlob blob) {
+    public static boolean isInColdStorage(@Nonnull ManagedBlob blob) {
         return isInColdStorage(getStatus(blob));
     }
 
-    public static boolean isInColdStorage(BlobStatus status) {
+    public static boolean isInColdStorage(@Nonnull BlobStatus status) {
         return StorageClass.GLACIER.toString().equals(status.getStorageClass());
     }
+
 }

--- a/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/action/PropagateMoveToColdStorageContentAction.java
+++ b/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/action/PropagateMoveToColdStorageContentAction.java
@@ -89,8 +89,8 @@ public class PropagateMoveToColdStorageContentAction implements StreamProcessorT
                     session.saveDocument(documentModel);
                 } catch (NuxeoException e) {
                     errorCount++;
-                    delta.inError(String.format("Cannot propagate move to cold storage for document %s: %s", document.getId(),
-                            e.getMessage()));
+                    delta.inError("Cannot propagate move to cold storage for document %s: %s".formatted(
+                            document.getId(), e.getMessage()));
                     log.warn("Could not propagate move to cold storage for document: {}", document::getId, () -> e);
                 }
             }

--- a/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/action/PropagateRestoreFromColdStorageContentAction.java
+++ b/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/action/PropagateRestoreFromColdStorageContentAction.java
@@ -30,7 +30,9 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.nuxeo.coldstorage.ColdStorageConstants;
+import org.nuxeo.coldstorage.ColdStorageHelper;
 import org.nuxeo.coldstorage.service.ColdStorageService;
+import org.nuxeo.coldstorage.service.RestoreContext;
 import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.DocumentModelList;
@@ -82,7 +84,17 @@ public class PropagateRestoreFromColdStorageContentAction implements StreamProce
                     continue;
                 }
                 try {
-                    service.proceedRestoreMainContent(session, document, false, false);
+                    var blobStatus = ColdStorageHelper.getBlobStatus(document);
+                    if (ColdStorageHelper.isDownloadable(blobStatus)) {
+                        service.proceedRestoreMainContent(
+                                RestoreContext.builder(session, document)
+                                              .storageLevel(ColdStorageHelper.isInColdStorage(blobStatus))
+                                              .build());
+                    } else {
+                        log.warn("Document: {} cannot be restored: blob not downloadable (storage class: {})",
+                                document::getId, blobStatus::getStorageClass);
+                        delta.incrementSkipCount();
+                    }
                 } catch (NuxeoException e) {
                     errorCount++;
                     delta.inError("Cannot propagate restore from cold storage for document %s: %s".formatted(

--- a/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/action/PropagateRestoreFromColdStorageContentAction.java
+++ b/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/action/PropagateRestoreFromColdStorageContentAction.java
@@ -85,8 +85,8 @@ public class PropagateRestoreFromColdStorageContentAction implements StreamProce
                     service.proceedRestoreMainContent(session, document, false, false);
                 } catch (NuxeoException e) {
                     errorCount++;
-                    delta.inError(String.format("Cannot propagate restore from cold storage for document %s: %s", document.getId(),
-                            e.getMessage()));
+                    delta.inError("Cannot propagate restore from cold storage for document %s: %s".formatted(
+                            document.getId(), e.getMessage()));
                     log.warn("Could not propagate restore from cold storage for document: {}", document::getId,
                             () -> e);
                 }

--- a/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/migrator/RestoreFromColdStorageMigrator.java
+++ b/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/migrator/RestoreFromColdStorageMigrator.java
@@ -1,0 +1,132 @@
+/*
+ * (C) Copyright 2026 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Guillaume Renard
+ */
+package org.nuxeo.coldstorage.migrator;
+
+import static org.nuxeo.coldstorage.ColdStorageConstants.COLD_STORAGE_FACET_NAME;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.nuxeo.coldstorage.ColdStorageConstants;
+import org.nuxeo.coldstorage.ColdStorageHelper;
+import org.nuxeo.coldstorage.service.ColdStorageService;
+import org.nuxeo.coldstorage.service.RestoreContext;
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.IdRef;
+import org.nuxeo.ecm.core.api.NuxeoException;
+import org.nuxeo.ecm.core.migrator.AbstractBulkMigrator;
+import org.nuxeo.runtime.api.Framework;
+import org.nuxeo.runtime.migration.MigrationDescriptor;
+
+/**
+ * Migrator to restore documents from cold storage.
+ * <p>
+ * This migrator is enabled when move to cold storage is blocked via the
+ * {@link ColdStorageConstants#COLD_STORAGE_RESTORE_MIGRATION_ENABLED_PROPERTY_NAME} property.
+ *
+ * @since 2025.2
+ */
+public class RestoreFromColdStorageMigrator extends AbstractBulkMigrator {
+
+    private static final Logger log = LogManager.getLogger(RestoreFromColdStorageMigrator.class);
+
+    public static final String MIGRATION_ID = "restore-from-cold-storage-migration";
+
+    public static final String MIGRATION_ENABLED_STATE = "enabled";
+
+    public static final String MIGRATION_DISABLED_STATE = "disabled";
+
+    public static final String MIGRATION_DONE_STATE = "done";
+
+    public RestoreFromColdStorageMigrator(MigrationDescriptor descriptor) {
+        super(descriptor);
+    }
+
+    @Override
+    protected String probeSession(CoreSession session) {
+        ColdStorageService service = Framework.getService(ColdStorageService.class);
+        if (service.isMoveToColdStorageBlocked()) {
+            // Check if there are any documents with ColdStorage facet
+            // If documents remain with the facet, it means they weren't restored (migration incomplete or skipped)
+            long count = session.queryProjection(
+                    "SELECT ecm:uuid FROM Document WHERE ecm:mixinType = '%s'".formatted(COLD_STORAGE_FACET_NAME), 1, 0)
+                                .size();
+            return count > 0 ? MIGRATION_ENABLED_STATE : MIGRATION_DONE_STATE;
+        }
+        return MIGRATION_DISABLED_STATE;
+    }
+
+    @Override
+    protected String getNXQLScrollQuery() {
+        // Query for all documents with ColdStorage facet - assume all are ready to be restored
+        return "SELECT * FROM Document WHERE ecm:mixinType = '%s'".formatted(COLD_STORAGE_FACET_NAME);
+    }
+
+    @Override
+    public void compute(CoreSession session, List<String> ids, Map<String, Serializable> properties) {
+        var service = Framework.getService(ColdStorageService.class);
+        for (String id : ids) {
+            var docRef = new IdRef(id);
+            if (!session.exists(docRef)) {
+                continue;
+            }
+
+            var doc = session.getDocument(docRef);
+
+            // Document may have been restored by a concurrent process - skip silently
+            if (!doc.hasFacet(COLD_STORAGE_FACET_NAME)) {
+                log.debug("Document: {} already restored from cold storage by concurrent process, skipping", id);
+                continue;
+            }
+
+            try {
+                // Get blob status once and check if downloadable
+                var blobStatus = ColdStorageHelper.getBlobStatus(doc);
+                if (ColdStorageHelper.isDownloadable(blobStatus)) {
+                    // Check if we need to restore at storage level (change storage class from GLACIER)
+                    boolean needsStorageLevelRestore = ColdStorageHelper.isInColdStorage(blobStatus);
+                    if (needsStorageLevelRestore) {
+                        log.debug("Restoring document: {} from cold storage (storage class: {})", () -> id,
+                                blobStatus::getStorageClass);
+                    } else {
+                        log.debug(
+                                "Restoring document: {} from cold storage (blob already at expected storage class: {})",
+                                () -> id, blobStatus::getStorageClass);
+                    }
+                    service.proceedRestoreMainContent(
+                            RestoreContext.builder(session, doc).storageLevel(needsStorageLevelRestore).build());
+                } else {
+                    // Not downloadable - log warning and skip (document keeps ColdStorage facet)
+                    log.warn("Document {} cannot be restored: blob not downloadable (storage class: {})", () -> id,
+                            blobStatus::getStorageClass);
+                }
+            } catch (NuxeoException e) {
+                log.error("Failed to restore document: {} from cold storage", id, e);
+            }
+        }
+    }
+
+    @Override
+    public void notifyStatusChange() {
+        // Nothing to do for this migrator
+    }
+}

--- a/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/service/ColdStorageService.java
+++ b/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/service/ColdStorageService.java
@@ -110,14 +110,37 @@ public interface ColdStorageService {
 
     /**
      * Internal use.
+     *
+     * @deprecated since 2025.2, use {@link #proceedRestoreMainContent(RestoreContext)} instead
      */
-    DocumentModel proceedRestoreMainContent(CoreSession session, DocumentModel documentModel, boolean notify);
+    @Deprecated(since = "2025.2")
+    default DocumentModel proceedRestoreMainContent(CoreSession session, DocumentModel documentModel, boolean notify) {
+        return proceedRestoreMainContent(session, documentModel, notify, true);
+    }
 
     /**
      * Internal use.
+     *
+     * @deprecated since 2025.2, use {@link #proceedRestoreMainContent(RestoreContext)} instead
      */
-    DocumentModel proceedRestoreMainContent(CoreSession session, DocumentModel documentModel, boolean notify,
-            boolean propagate);
+    @Deprecated(since = "2025.2")
+    default DocumentModel proceedRestoreMainContent(CoreSession session, DocumentModel documentModel, boolean notify,
+            boolean propagate) {
+        return proceedRestoreMainContent(RestoreContext.builder(session, documentModel)
+                                                       .notify(notify)
+                                                       .propagate(propagate)
+                                                       .storageLevel(true)
+                                                       .build());
+    }
+
+    /**
+     * Internal use. Restores the main content from cold storage using the provided context.
+     *
+     * @param context the restore context containing the core session, document model and restore options
+     * @return the updated document model
+     * @since 2025.2
+     */
+    DocumentModel proceedRestoreMainContent(RestoreContext context);
 
     /**
      * Internal use.

--- a/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/service/ColdStorageService.java
+++ b/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/service/ColdStorageService.java
@@ -19,6 +19,8 @@
 
 package org.nuxeo.coldstorage.service;
 
+import static org.nuxeo.coldstorage.ColdStorageConstants.COLD_STORAGE_RESTORE_MIGRATION_ENABLED_PROPERTY_NAME;
+
 import java.time.Duration;
 
 import org.nuxeo.ecm.core.api.Blob;
@@ -27,6 +29,7 @@ import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.DocumentRef;
 import org.nuxeo.ecm.core.api.NuxeoException;
 import org.nuxeo.ecm.core.blob.ManagedBlob;
+import org.nuxeo.runtime.api.Framework;
 
 /**
  * @since 2021.0.0
@@ -158,5 +161,17 @@ public interface ColdStorageService {
      * @since 2023.2
      */
     void propagateRestoreFromColdStorage(CoreSession session, String blobDigest);
+
+    /**
+     * Checks if move to cold storage operations are globally blocked via configuration.
+     *
+     * @return {@code true} if the
+     *         {@value org.nuxeo.coldstorage.ColdStorageConstants#COLD_STORAGE_RESTORE_MIGRATION_ENABLED_PROPERTY_NAME}
+     *         property is set to {@code true}, {@code false} otherwise
+     * @since 2025.2
+     */
+    default boolean isMoveToColdStorageBlocked() {
+        return Framework.isBooleanPropertyTrue(COLD_STORAGE_RESTORE_MIGRATION_ENABLED_PROPERTY_NAME);
+    }
 
 }

--- a/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/service/ColdStorageServiceImpl.java
+++ b/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/service/ColdStorageServiceImpl.java
@@ -174,7 +174,7 @@ public class ColdStorageServiceImpl extends DefaultComponent implements ColdStor
     }
 
     @Override
-    public void stop(ComponentContext context) throws InterruptedException {
+    public void stop(ComponentContext context) {
         defaultRendition = null;
         renditionByDocType = null;
         renditionByFacets = null;
@@ -277,7 +277,7 @@ public class ColdStorageServiceImpl extends DefaultComponent implements ColdStor
                 BlobUpdateContext updateContext = new BlobUpdateContext(key).withColdStorageClass(true);
                 Framework.getService(BlobManager.class).getBlobProvider(coldContent).updateBlob(updateContext);
             } else {
-                log.warn("Main blob {} for document {} is already in cold storage with storage class {}",
+                log.debug("Main blob {} for document {} is already in cold storage with storage class {}",
                         coldContent::getDigest, documentModel::getId, oldStatus::getStorageClass);
             }
         } catch (IOException e) {
@@ -326,7 +326,7 @@ public class ColdStorageServiceImpl extends DefaultComponent implements ColdStor
         }
         BlobStatus blobStatus = ColdStorageHelper.getBlobStatus(documentModel);
         Function<DocumentModel, Boolean> doNotify;
-        DocumentModel docResult = null;
+        DocumentModel docResult;
         Blob coldContent = (Blob) documentModel.getPropertyValue(COLD_STORAGE_CONTENT_PROPERTY);
         String key = getContentBlobKey(coldContent);
         if (ColdStorageHelper.isDownloadable(blobStatus)) {
@@ -525,10 +525,10 @@ public class ColdStorageServiceImpl extends DefaultComponent implements ColdStor
     }
 
     /**
-     * Restore from ColdStorage all documents referencing the given blob digests as main content.
+     * Restore from ColdStorage all documents referencing the given blob digest as main content.
      *
      * @param session the session
-     * @param blobDigests the blob digests
+     * @param blobDigest the blob digest
      */
     public void propagateRestoreFromColdStorage(CoreSession session, String blobDigest) {
         if (session.queryProjection(String.format("SELECT " + NXQL.ECM_UUID + " FROM Document WHERE %s/digest = '%s'",
@@ -600,14 +600,14 @@ public class ColdStorageServiceImpl extends DefaultComponent implements ColdStor
             }
             return true;
         } else if (!blobStatus.isOngoingRestore()) {
-            // the blob was probably retrieved and it already went back to cold storage
+            // the blob was probably retrieved, and it already went back to cold storage
             // Let's flag it as not being retrieved
             log.debug("Document {} is flagged as being retrieved but not its blob", doc::getPath);
             doc.setPropertyValue(COLD_STORAGE_BEING_RETRIEVED_PROPERTY, false);
             if (doc.isVersion()) {
                 doc.putContextData(ALLOW_VERSION_WRITE, true);
             }
-            doc = session.saveDocument(doc);
+            session.saveDocument(doc);
         }
         return false;
     }

--- a/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/service/ColdStorageServiceImpl.java
+++ b/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/service/ColdStorageServiceImpl.java
@@ -529,7 +529,8 @@ public class ColdStorageServiceImpl extends DefaultComponent implements ColdStor
         BulkService bulkService = Framework.getService(BulkService.class);
         String username = SecurityConstants.SYSTEM_USERNAME;
         String commandId = bulkService.submitTransactional(
-                new BulkCommand.Builder(PropagateMoveToColdStorageContentAction.ACTION_NAME, query, username).build());
+                new BulkCommand.Builder(PropagateMoveToColdStorageContentAction.ACTION_NAME, query,
+                        username).repository(session.getRepositoryName()).build());
 
         log.debug("Moving documents referencing blob: {}, status: {}", () -> blobDigest,
                 () -> bulkService.getStatus(commandId));
@@ -552,8 +553,9 @@ public class ColdStorageServiceImpl extends DefaultComponent implements ColdStor
 
         BulkService bulkService = Framework.getService(BulkService.class);
         String username = SecurityConstants.SYSTEM_USERNAME;
-        String commandId = bulkService.submitTransactional(new BulkCommand.Builder(
-                PropagateRestoreFromColdStorageContentAction.ACTION_NAME, query, username).build());
+        String commandId = bulkService.submitTransactional(
+                new BulkCommand.Builder(PropagateRestoreFromColdStorageContentAction.ACTION_NAME, query,
+                        username).repository(session.getRepositoryName()).build());
         log.debug("Restoring documents referencing blob: {}, status: {}", () -> blobDigest,
                 () -> bulkService.getStatus(commandId));
     }

--- a/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/service/ColdStorageServiceImpl.java
+++ b/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/service/ColdStorageServiceImpl.java
@@ -337,7 +337,10 @@ public class ColdStorageServiceImpl extends DefaultComponent implements ColdStor
                 log.warn(
                         "Cold content blob: {} of document: {} is already restored. Restoring the Nuxeo document instead of retrieving.",
                         key, documentRef);
-                DocumentModel restored = proceedRestoreMainContent(session, documentModel, false, false);
+                // Only update storage level if blob is still in cold storage (GLACIER)
+                boolean needsStorageLevelRestore = ColdStorageHelper.isInColdStorage(blobStatus);
+                DocumentModel restored = proceedRestoreMainContent(
+                        RestoreContext.builder(session, documentModel).storageLevel(needsStorageLevelRestore).build());
                 // Fire event for audit purpose
                 fireEvent(restored, restored.getCoreSession(), COLD_STORAGE_CONTENT_TO_RESTORE_EVENT_NAME);
                 return restored;
@@ -423,7 +426,12 @@ public class ColdStorageServiceImpl extends DefaultComponent implements ColdStor
         BlobStatus blobStatus = ColdStorageHelper.getBlobStatus(documentModel);
         if (ColdStorageHelper.isDownloadable(blobStatus)) {
             // Restore the main content synchronously no need to notify.
-            documentModel = proceedRestoreMainContent(session, documentModel, false);
+            // Only update storage level if blob is still in cold storage (GLACIER)
+            boolean needsStorageLevelRestore = ColdStorageHelper.isInColdStorage(blobStatus);
+            documentModel = proceedRestoreMainContent(RestoreContext.builder(session, documentModel)
+                                                                    .propagate(true)
+                                                                    .storageLevel(needsStorageLevelRestore)
+                                                                    .build());
         } else {
             // Need to retrieve the doc first, restoration will happen asynchronously once the doc will be retrieved
             // Subscribe the user to receive a mail notification once the content is restored
@@ -445,24 +453,22 @@ public class ColdStorageServiceImpl extends DefaultComponent implements ColdStor
     }
 
     @Override
-    public DocumentModel proceedRestoreMainContent(CoreSession session, DocumentModel documentModel, boolean notify) {
-        return proceedRestoreMainContent(session, documentModel, notify, true);
-    }
-
-    @Override
-    public DocumentModel proceedRestoreMainContent(CoreSession session, DocumentModel documentModel, boolean notify,
-            boolean propagate) {
+    public DocumentModel proceedRestoreMainContent(RestoreContext context) {
+        CoreSession session = context.getCoreSession();
+        DocumentModel documentModel = context.getDocumentModel();
         Blob coldContent = (Blob) documentModel.getPropertyValue(COLD_STORAGE_CONTENT_PROPERTY);
         if (coldContent == null) {
             throw new NuxeoException(String.format("Cold content is null for document: %s", documentModel.getId()));
         }
-        try {
-            String key = getContentBlobKey(coldContent);
-            BlobUpdateContext updateContext = new BlobUpdateContext(key).withColdStorageClass(false);
-            Framework.getService(BlobManager.class).getBlobProvider(coldContent).updateBlob(updateContext);
-        } catch (IOException e) {
-            log.error("Could not restore document {}", documentModel::getId);
-            throw new NuxeoException(e);
+        if (context.isStorageLevel()) {
+            try {
+                String key = getContentBlobKey(coldContent);
+                BlobUpdateContext updateContext = new BlobUpdateContext(key).withColdStorageClass(false);
+                Framework.getService(BlobManager.class).getBlobProvider(coldContent).updateBlob(updateContext);
+            } catch (IOException e) {
+                log.error("Could not restore document {}", documentModel::getId);
+                throw new NuxeoException(e);
+            }
         }
         // We must reset all properties of the Cold Storage facet before removing it, otherwise the properties will
         // still have the old values if we add back the facet (i.e. send back to cold storage)
@@ -495,13 +501,13 @@ public class ColdStorageServiceImpl extends DefaultComponent implements ColdStor
         }
         documentModel = session.saveDocument(documentModel);
 
-        if (propagate) {
+        if (context.isPropagate()) {
             // Submit Bulk action to update documents referencing the same blob
             propagateRestoreFromColdStorage(session, coldContent.getDigest());
         }
 
         // Send notification
-        if (notify) {
+        if (context.isNotify()) {
             DocumentEventContext ctx = new DocumentEventContext(session, session.getPrincipal(), documentModel);
             EventService eventService = Framework.getService(EventService.class);
             ctx.setProperty(COLD_STORAGE_CONTENT_RESTORED_EVENT_NAME, "true");
@@ -574,7 +580,13 @@ public class ColdStorageServiceImpl extends DefaultComponent implements ColdStor
             // Check if the Document should be restored definitively
             Serializable undoMove = doc.getPropertyValue(COLD_STORAGE_TO_BE_RESTORED_PROPERTY);
             if (Boolean.TRUE.equals(undoMove)) {
-                proceedRestoreMainContent(session, doc, true);
+                // Only update storage level if blob is still in cold storage (GLACIER)
+                boolean needsStorageLevelRestore = ColdStorageHelper.isInColdStorage(blobStatus);
+                proceedRestoreMainContent(RestoreContext.builder(session, doc)
+                                                        .notify(true)
+                                                        .propagate(true)
+                                                        .storageLevel(needsStorageLevelRestore)
+                                                        .build());
             } else {
                 doc.setPropertyValue(COLD_STORAGE_BEING_RETRIEVED_PROPERTY, false);
 

--- a/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/service/ColdStorageServiceImpl.java
+++ b/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/service/ColdStorageServiceImpl.java
@@ -233,6 +233,11 @@ public class ColdStorageServiceImpl extends DefaultComponent implements ColdStor
 
     @Override
     public DocumentModel proceedMoveToColdStorage(CoreSession session, DocumentRef documentRef) {
+        if (isMoveToColdStorageBlocked()) {
+            log.debug("Move to cold storage is globally blocked via configuration");
+            throw new NuxeoException("Move to cold storage operations are currently blocked", SC_FORBIDDEN);
+        }
+
         DocumentModel documentModel = session.getDocument(documentRef);
         if (session.isUnderRetentionOrLegalHold(documentRef)) {
             log.debug("The document {} is under retention or legal hold and cannot be moved to cold storage",

--- a/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/service/RestoreContext.java
+++ b/nuxeo-coldstorage/src/main/java/org/nuxeo/coldstorage/service/RestoreContext.java
@@ -1,0 +1,184 @@
+/*
+ * (C) Copyright 2026 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Guillaume Renard
+ */
+package org.nuxeo.coldstorage.service;
+
+import jakarta.annotation.Nonnull;
+
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+
+/**
+ * Context for restore operations from cold storage.
+ * <p>
+ * This class provides a builder pattern for configuring restore operations. Use the static factory method
+ * {@link #builder(CoreSession, DocumentModel)} to create a new builder instance.
+ *
+ * @since 2025.2
+ */
+public class RestoreContext {
+
+    protected final CoreSession coreSession;
+
+    protected final DocumentModel documentModel;
+
+    protected final boolean notify;
+
+    protected final boolean propagate;
+
+    protected final boolean storageLevel;
+
+    protected RestoreContext(Builder builder) {
+        this.coreSession = builder.coreSession;
+        this.documentModel = builder.documentModel;
+        this.notify = builder.notify;
+        this.propagate = builder.propagate;
+        this.storageLevel = builder.storageLevel;
+    }
+
+    /**
+     * @return the core session
+     */
+    public CoreSession getCoreSession() {
+        return coreSession;
+    }
+
+    /**
+     * @return the document model to restore from cold storage
+     */
+    public DocumentModel getDocumentModel() {
+        return documentModel;
+    }
+
+    /**
+     * @return {@code true} if a notification event should be fired after restoration, {@code false} otherwise
+     */
+    public boolean isNotify() {
+        return notify;
+    }
+
+    /**
+     * @return {@code true} if the restore should be propagated to other documents with the same blob digest,
+     *         {@code false} otherwise
+     */
+    public boolean isPropagate() {
+        return propagate;
+    }
+
+    /**
+     * @return {@code true} if the blob storage class should be updated at S3 level (e.g., from GLACIER to
+     *         INTELLIGENT_TIERING), {@code false} to skip storage level changes
+     */
+    public boolean isStorageLevel() {
+        return storageLevel;
+    }
+
+    /**
+     * Creates a new builder for the specified document.
+     *
+     * @param coreSession the core session
+     * @param documentModel the document to restore from cold storage
+     * @return a new builder instance with default values (all flags set to {@code false})
+     */
+    public static Builder builder(@Nonnull CoreSession coreSession, @Nonnull DocumentModel documentModel) {
+        return new Builder(coreSession, documentModel);
+    }
+
+    /**
+     * Builder for {@link RestoreContext}.
+     * <p>
+     * All boolean flags default to {@code false}. Use the builder methods to override defaults.
+     */
+    public static class Builder {
+
+        protected final CoreSession coreSession;
+
+        protected final DocumentModel documentModel;
+
+        protected boolean notify = false;
+
+        protected boolean propagate = false;
+
+        protected boolean storageLevel = false;
+
+        protected Builder(CoreSession coreSession, DocumentModel documentModel) {
+            this.coreSession = coreSession;
+            this.documentModel = documentModel;
+        }
+
+        /**
+         * Sets whether to fire a notification event after restoration.
+         * <p>
+         * When {@code true}, a {@code COLD_STORAGE_CONTENT_RESTORED_EVENT_NAME} event will be fired, which can trigger
+         * email notifications to subscribed users.
+         *
+         * @param notify {@code true} to send notifications, {@code false} otherwise
+         * @return this builder for method chaining
+         */
+        public Builder notify(boolean notify) {
+            this.notify = notify;
+            return this;
+        }
+
+        /**
+         * Sets whether to propagate the restore operation to other documents.
+         * <p>
+         * When {@code true}, a bulk action will be submitted to restore all other documents that reference the same
+         * blob digest. This is useful when multiple documents share the same content.
+         * <p>
+         * Set to {@code false} when the restore is already part of a propagation operation to avoid infinite loops.
+         *
+         * @param propagate {@code true} to propagate restore to related documents, {@code false} otherwise
+         * @return this builder for method chaining
+         */
+        public Builder propagate(boolean propagate) {
+            this.propagate = propagate;
+            return this;
+        }
+
+        /**
+         * Sets whether to update the blob storage class at S3 level.
+         * <p>
+         * When {@code true}, the blob's storage class will be changed from GLACIER to the default storage class (e.g.,
+         * INTELLIGENT_TIERING) using the S3 API. This involves an S3 {@code updateBlob} call.
+         * <p>
+         * When {@code false}, only the Nuxeo document metadata will be updated without touching S3. This is useful when
+         * the blob has already been restored at S3 level (e.g., via S3 Batch Operations) and only the Nuxeo document
+         * state needs to be synchronized.
+         * <p>
+         * <strong>Performance tip:</strong> Set to {@code false} if you know the blob is already at the expected
+         * storage class to avoid unnecessary S3 API calls.
+         *
+         * @param storageLevel {@code true} to update storage class at S3 level, {@code false} to skip S3 operations
+         * @return this builder for method chaining
+         */
+        public Builder storageLevel(boolean storageLevel) {
+            this.storageLevel = storageLevel;
+            return this;
+        }
+
+        /**
+         * Builds the {@link RestoreContext} with the configured values.
+         *
+         * @return a new immutable {@link RestoreContext} instance
+         */
+        public RestoreContext build() {
+            return new RestoreContext(this);
+        }
+    }
+}

--- a/nuxeo-coldstorage/src/main/resources/META-INF/MANIFEST.MF
+++ b/nuxeo-coldstorage/src/main/resources/META-INF/MANIFEST.MF
@@ -13,4 +13,5 @@ Nuxeo-Component: OSGI-INF/coldstorage-core-types-contrib.xml,
  OSGI-INF/coldstorage-security.xml,
  OSGI-INF/coldstorage-bulk-contrib.xml,
  OSGI-INF/coldstorage-service.xml,
- OSGI-INF/coldstorage-rendition-contrib.xml
+ OSGI-INF/coldstorage-rendition-contrib.xml,
+ OSGI-INF/coldstorage-restore-migration.xml

--- a/nuxeo-coldstorage/src/main/resources/OSGI-INF/coldstorage-restore-migration.xml
+++ b/nuxeo-coldstorage/src/main/resources/OSGI-INF/coldstorage-restore-migration.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<component name="org.nuxeo.coldstorage.migrator" version="1.0">
+
+  <extension target="org.nuxeo.runtime.migration.MigrationService" point="configuration">
+
+    <migration id="restore-from-cold-storage-migration">
+      <description label="migration.coldstorage.restore">Restore documents from cold storage when move to cold storage is blocked</description>
+      <class>org.nuxeo.coldstorage.migrator.RestoreFromColdStorageMigrator</class>
+      <defaultState>disabled</defaultState>
+      <state id="disabled">
+        <description label="migration.coldstorage.restore.disabled">Move to cold storage is not blocked</description>
+      </state>
+      <state id="enabled">
+        <description label="migration.coldstorage.restore.enabled">Move to cold storage is blocked, documents in cold storage need restoration</description>
+      </state>
+      <state id="done">
+        <description label="migration.coldstorage.restore.done">All documents have been restored from cold storage</description>
+      </state>
+
+      <step id="enabled-to-done" fromState="enabled" toState="done">
+        <description label="migration.coldstorage.restore.step">Restore downloadable documents from cold storage</description>
+      </step>
+    </migration>
+
+  </extension>
+
+</component>
+

--- a/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/MockS3BlobProvider.java
+++ b/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/MockS3BlobProvider.java
@@ -21,34 +21,203 @@ package org.nuxeo.coldstorage;
 import static software.amazon.awssdk.services.s3.model.StorageClass.GLACIER;
 import static software.amazon.awssdk.services.s3.model.StorageClass.STANDARD;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serial;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
-import org.nuxeo.ecm.core.DummyBlobProvider;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.IOUtils;
+import org.nuxeo.ecm.core.api.Blob;
+import org.nuxeo.ecm.core.api.NuxeoException;
+import org.nuxeo.ecm.core.blob.AbstractBlobProvider;
+import org.nuxeo.ecm.core.blob.BlobInfo;
 import org.nuxeo.ecm.core.blob.BlobStatus;
 import org.nuxeo.ecm.core.blob.BlobUpdateContext;
+import org.nuxeo.ecm.core.blob.ManagedBlob;
+import org.nuxeo.ecm.core.blob.SimpleManagedBlob;
 
 /**
- * Extends {@link DummyBlobProvider} to mock S3 storage classes and restore behavior.
+ * Mock S3 blob provider for testing cold storage functionality.
+ * <p>
+ * This provider simulates S3 storage classes (STANDARD, GLACIER) and restore behavior. Keys are based on blob digests.
  *
  * @since 2025.1
  */
-public class MockS3BlobProvider extends DummyBlobProvider {
+public class MockS3BlobProvider extends AbstractBlobProvider {
+
+    protected static final Duration RESTORE_DELAY = Duration.ofSeconds(1);
+
+    protected Map<String, byte[]> blobs;
+
+    protected Map<String, BlobStatus> blobsStatus;
 
     @Override
-    public void updateBlob(BlobUpdateContext blobUpdateContext) throws IOException {
-        if (blobUpdateContext != null) {
-            BlobStatus status = blobsStatus.getOrDefault(blobUpdateContext.key, new BlobStatus());
-            if (blobUpdateContext.coldStorageClass != null) {
-                status.withStorageClass(
-                        blobUpdateContext.coldStorageClass.inColdStorage ? GLACIER.toString() : STANDARD.toString());
+    public void initialize(String blobProviderId, Map<String, String> properties) throws IOException {
+        super.initialize(blobProviderId, properties);
+        blobs = new ConcurrentHashMap<>();
+        blobsStatus = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public void close() {
+        blobs.clear();
+        blobsStatus.clear();
+    }
+
+    /**
+     * Adds a status for a blob. This method is used by tests to manually set blob status.
+     *
+     * @param blob the managed blob
+     * @param status the status to set
+     */
+    public void addStatus(ManagedBlob blob, BlobStatus status) {
+        blobsStatus.put(getBlobKey(blob), status);
+    }
+
+    /**
+     * Extracts the blob key from a managed blob, stripping the provider prefix if present.
+     *
+     * @param blob the managed blob
+     * @return the blob key (digest)
+     */
+    protected String getBlobKey(ManagedBlob blob) {
+        String key = blob.getKey();
+        int colon = key.indexOf(':');
+        return colon < 0 ? key : key.substring(colon + 1);
+    }
+
+    @Override
+    public BlobStatus getStatus(ManagedBlob blob) {
+        return blobsStatus.getOrDefault(getBlobKey(blob), new BlobStatus());
+    }
+
+    @Override
+    public Blob readBlob(BlobInfo blobInfo) {
+        return new SimpleManagedBlob(blobProviderId, blobInfo) {
+            @Serial
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public InputStream getStream() throws IOException {
+                if (!getStatus(this).isDownloadable()) {
+                    throw new IOException(String.format("Blob %s is not downloadable", key));
+                }
+                String k = getBlobKey(this);
+                byte[] bytes = blobs.get(k);
+                if (bytes == null) {
+                    throw new IOException(String.format("Blob %s not found", key));
+                }
+                return new ByteArrayInputStream(bytes);
             }
-            if (blobUpdateContext.restoreForDuration != null) {
+        };
+    }
+
+    @Override
+    public void updateBlob(BlobUpdateContext blobUpdateContext) {
+        if (blobUpdateContext == null) {
+            return;
+        }
+
+        // Handle restore requests - requires special async handling
+        if (blobUpdateContext.restoreForDuration != null) {
+            blobsStatus.compute(blobUpdateContext.key, (key, existingStatus) -> {
+                BlobStatus status = existingStatus != null ? existingStatus : new BlobStatus();
                 if (STANDARD.toString().equals(status.getStorageClass())) {
                     throw new IllegalStateException("Cannot restore a blob with default storage class");
                 }
-            }
-            this.blobsStatus.put(blobUpdateContext.key, status);
-            super.updateBlob(blobUpdateContext);
+                return status.withOngoingRestore(true);
+            });
+
+            // Simulate asynchronous restore
+            Runnable restoreCmd = () -> blobsStatus.compute(blobUpdateContext.key, (key, existingStatus) -> {
+                if (existingStatus == null) {
+                    return null;
+                }
+                return existingStatus.withDownloadable(true)
+                                     .withOngoingRestore(false)
+                                     .withDownloadableUntil(
+                                             Instant.now().plus(blobUpdateContext.restoreForDuration.duration));
+            });
+            CompletableFuture.delayedExecutor(RESTORE_DELAY.toMillis(), TimeUnit.MILLISECONDS).execute(restoreCmd);
+            return;
+        }
+
+        // Handle cold storage class changes
+        if (blobUpdateContext.coldStorageClass != null) {
+            blobsStatus.compute(blobUpdateContext.key, (key, existingStatus) -> {
+                BlobStatus status = existingStatus != null ? existingStatus : new BlobStatus();
+                String storageClass = blobUpdateContext.coldStorageClass.inColdStorage ? GLACIER.toString()
+                        : STANDARD.toString();
+                return status.withStorageClass(storageClass)
+                             .withDownloadable(!blobUpdateContext.coldStorageClass.inColdStorage);
+            });
         }
     }
+
+    /**
+     * Test helper to wait for asynchronous blob restore operations to complete.
+     * <p>
+     * Waits for {@link #RESTORE_DELAY} plus a 200ms buffer to ensure the async restore executor has finished updating
+     * blob status. The buffer accounts for thread scheduling delays and ensures deterministic test behavior.
+     *
+     * @throws RuntimeException if the thread is interrupted while waiting
+     */
+    public static void waitForRestore() {
+        try {
+            Thread.sleep(MockS3BlobProvider.RESTORE_DELAY.plusMillis(200));
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Writes a blob to storage using digest as the key.
+     * <p>
+     * Simulates blob deduplication based on digest. If the blob doesn't have a digest, one is computed from the blob
+     * content.
+     *
+     * @param blob the blob to write
+     * @return the digest key
+     */
+    @Override
+    public String writeBlob(Blob blob) throws IOException {
+        String digest = blob.getDigest();
+
+        // If no digest is set, compute one from the blob content
+        if (digest == null) {
+            byte[] bytes;
+            try (InputStream in = blob.getStream()) {
+                bytes = IOUtils.toByteArray(in);
+            }
+            try {
+                MessageDigest md = MessageDigest.getInstance("MD5");
+                digest = Hex.encodeHexString(md.digest(bytes));
+            } catch (NoSuchAlgorithmException e) {
+                throw new NuxeoException("MD5 algorithm not available", e);
+            }
+            // Store the blob with computed digest
+            blobs.putIfAbsent(digest, bytes);
+        } else {
+            // Use computeIfAbsent for thread-safe deduplication
+            blobs.computeIfAbsent(digest, k -> {
+                try (InputStream in = blob.getStream()) {
+                    return IOUtils.toByteArray(in);
+                } catch (IOException e) {
+                    throw new NuxeoException("Failed to read blob stream", e);
+                }
+            });
+        }
+
+        return digest;
+    }
+
 }

--- a/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/migrator/TestRestoreFromColdStorageMigrator.java
+++ b/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/migrator/TestRestoreFromColdStorageMigrator.java
@@ -1,0 +1,421 @@
+/*
+ * (C) Copyright 2026 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Guillaume Renard
+ */
+package org.nuxeo.coldstorage.migrator;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.nuxeo.coldstorage.ColdStorageConstants.COLD_STORAGE_CONTENT_PROPERTY;
+import static org.nuxeo.coldstorage.ColdStorageConstants.COLD_STORAGE_FACET_NAME;
+import static org.nuxeo.coldstorage.ColdStorageConstants.COLD_STORAGE_RESTORE_MIGRATION_ENABLED_PROPERTY_NAME;
+import static org.nuxeo.coldstorage.ColdStorageConstants.FILE_CONTENT_PROPERTY;
+import static org.nuxeo.coldstorage.MockS3BlobProvider.waitForRestore;
+import static org.nuxeo.coldstorage.migrator.RestoreFromColdStorageMigrator.MIGRATION_DISABLED_STATE;
+import static org.nuxeo.coldstorage.migrator.RestoreFromColdStorageMigrator.MIGRATION_DONE_STATE;
+import static org.nuxeo.coldstorage.migrator.RestoreFromColdStorageMigrator.MIGRATION_ENABLED_STATE;
+import static org.nuxeo.coldstorage.migrator.RestoreFromColdStorageMigrator.MIGRATION_ID;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.UUID;
+
+import jakarta.inject.Inject;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.nuxeo.coldstorage.ColdStorageHelper;
+import org.nuxeo.coldstorage.DummyColdStorageFeature;
+import org.nuxeo.coldstorage.MockS3BlobProvider;
+import org.nuxeo.coldstorage.service.ColdStorageService;
+import org.nuxeo.coldstorage.service.ColdStorageServiceImpl;
+import org.nuxeo.ecm.core.api.Blob;
+import org.nuxeo.ecm.core.api.Blobs;
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.blob.BlobManager;
+import org.nuxeo.ecm.core.blob.BlobUpdateContext;
+import org.nuxeo.ecm.core.blob.ManagedBlob;
+import org.nuxeo.runtime.api.Framework;
+import org.nuxeo.runtime.migration.MigrationService;
+import org.nuxeo.runtime.test.runner.Features;
+import org.nuxeo.runtime.test.runner.FeaturesRunner;
+import org.nuxeo.runtime.test.runner.TransactionalFeature;
+
+/**
+ * Tests for the restore from cold storage migration.
+ *
+ * @since 2025.2
+ */
+@RunWith(FeaturesRunner.class)
+@Features(DummyColdStorageFeature.class)
+public class TestRestoreFromColdStorageMigrator {
+
+    protected static final String FILE_CONTENT = "foo and boo";
+
+    @Inject
+    protected CoreSession session;
+
+    @Inject
+    protected TransactionalFeature transactionalFeature;
+
+    @Inject
+    protected MigrationService migrationService;
+
+    @Inject
+    protected ColdStorageService coldStorageService;
+
+    @After
+    public void tearDown() {
+        // Reset the framework property after each test
+        Framework.getProperties().remove(COLD_STORAGE_RESTORE_MIGRATION_ENABLED_PROPERTY_NAME);
+    }
+
+    @Test
+    public void testMigrationDisabledByDefault() {
+        var status = migrationService.getStatus(MIGRATION_ID);
+        assertNotNull("Migration should be registered", status);
+        assertEquals("Migration should be in disabled state by default", MIGRATION_DISABLED_STATE, status.getState());
+    }
+
+    @Test
+    public void testMigrationWithDocumentsInColdStorage() {
+        // Create a document and move it to cold storage
+        var doc = createFileDocument(session);
+        session.save();
+        transactionalFeature.nextTransaction();
+
+        doc = moveContentToColdStorage(session, doc);
+        session.save();
+        transactionalFeature.nextTransaction();
+
+        // Verify document is in cold storage
+        doc = session.getDocument(doc.getRef());
+        checkMoveContent(doc);
+
+        // Now enable the blocking property
+        Framework.getProperties().setProperty(COLD_STORAGE_RESTORE_MIGRATION_ENABLED_PROPERTY_NAME, "true");
+
+        // Probe migration state - should be enabled since doc is in cold storage
+        var state = migrationService.probeAndSetState(MIGRATION_ID);
+        assertEquals("Migration should be in enabled state when documents are in cold storage", MIGRATION_ENABLED_STATE,
+                state);
+
+        // Verify status
+        var status = migrationService.getStatus(MIGRATION_ID);
+        assertEquals("Migration status should be enabled", MIGRATION_ENABLED_STATE, status.getState());
+    }
+
+    @Test
+    public void testMigrationRestoreWithDownloadableBlob() {
+        // Create a document and move it to cold storage
+        var doc = createFileDocument(session);
+        session.save();
+        transactionalFeature.nextTransaction();
+
+        doc = moveContentToColdStorage(session, doc);
+        session.save();
+        transactionalFeature.nextTransaction();
+
+        // Verify document is in cold storage
+        doc = session.getDocument(doc.getRef());
+        checkMoveContent(doc);
+        assertTrue("Document should have ColdStorage facet", doc.hasFacet(COLD_STORAGE_FACET_NAME));
+
+        // Simulate blob retrieval at provider level (like when requestRetrieve is called externally)
+        var coldContent = (ManagedBlob) doc.getPropertyValue(COLD_STORAGE_CONTENT_PROPERTY);
+        var blobManager = Framework.getService(BlobManager.class);
+        var blobProvider = (MockS3BlobProvider) blobManager.getBlobProvider(coldContent.getProviderId());
+        var key = ColdStorageServiceImpl.getContentBlobKey(coldContent);
+        var updateContext = new BlobUpdateContext(key).withRestoreForDuration(Duration.ofDays(1));
+        blobProvider.updateBlob(updateContext);
+
+        // Wait for the restore to complete (MockS3BlobProvider simulates async restore)
+        waitForRestore();
+        transactionalFeature.nextTransaction();
+
+        // Enable blocking property
+        Framework.getProperties().setProperty(COLD_STORAGE_RESTORE_MIGRATION_ENABLED_PROPERTY_NAME, "true");
+
+        // Probe migration state - should be enabled
+        var state = migrationService.probeAndSetState(MIGRATION_ID);
+        assertEquals("Migration should be in enabled state", MIGRATION_ENABLED_STATE, state);
+
+        // Run the migration
+        migrationService.runStep(MIGRATION_ID, MIGRATION_ENABLED_STATE + "-to-" + MIGRATION_DONE_STATE);
+
+        // Wait for migration to complete
+        await().atMost(Duration.ofMinutes(1)).until(() -> !migrationService.getStatus(MIGRATION_ID).isRunning());
+        transactionalFeature.nextTransaction();
+
+        // Verify document was restored and no longer has ColdStorage facet
+        doc = session.getDocument(doc.getRef());
+        assertFalse("Document should not have ColdStorage facet after migration",
+                doc.hasFacet(COLD_STORAGE_FACET_NAME));
+        assertNotNull("Document should have main content restored", doc.getPropertyValue("file:content"));
+
+        // Probe state again - should be done since no documents remain in cold storage
+        state = migrationService.probeAndSetState(MIGRATION_ID);
+        assertEquals("Migration should be in done state after successful restore", MIGRATION_DONE_STATE, state);
+    }
+
+    @Test
+    public void testMigrationWithNonDownloadableBlob() {
+        // Create a document and move it to cold storage
+        var doc = createFileDocument(session);
+        session.save();
+        transactionalFeature.nextTransaction();
+
+        doc = moveContentToColdStorage(session, doc);
+        session.save();
+        transactionalFeature.nextTransaction();
+
+        // Verify document is in cold storage
+        doc = session.getDocument(doc.getRef());
+        checkMoveContent(doc);
+        assertTrue("Document should have ColdStorage facet", doc.hasFacet(COLD_STORAGE_FACET_NAME));
+
+        // Do NOT restore the blob - leave it in cold storage (non-downloadable)
+
+        // Enable blocking property
+        Framework.getProperties().setProperty(COLD_STORAGE_RESTORE_MIGRATION_ENABLED_PROPERTY_NAME, "true");
+
+        // Probe migration state - should be enabled
+        var state = migrationService.probeAndSetState(MIGRATION_ID);
+        assertEquals("Migration should be in enabled state", MIGRATION_ENABLED_STATE, state);
+
+        // Run the migration
+        migrationService.runStep(MIGRATION_ID, MIGRATION_ENABLED_STATE + "-to-" + MIGRATION_DONE_STATE);
+
+        // Wait for migration to complete
+        await().atMost(Duration.ofMinutes(1)).until(() -> !migrationService.getStatus(MIGRATION_ID).isRunning());
+
+        // Advance transaction to avoid stale reads
+        transactionalFeature.nextTransaction();
+
+        // Verify document still has ColdStorage facet (restore was skipped)
+        doc = session.getDocument(doc.getRef());
+        assertTrue("Document should still have ColdStorage facet when blob is not downloadable",
+                doc.hasFacet(COLD_STORAGE_FACET_NAME));
+
+        // Probe state again - should still be enabled since document remains in cold storage
+        state = migrationService.probeAndSetState(MIGRATION_ID);
+        assertEquals("Migration should remain in enabled state when documents cannot be restored",
+                MIGRATION_ENABLED_STATE, state);
+    }
+
+    @Test
+    public void testMigrationDoneWhenNoDocuments() {
+        // Enable blocking without any documents in cold storage
+        Framework.getProperties().setProperty(COLD_STORAGE_RESTORE_MIGRATION_ENABLED_PROPERTY_NAME, "true");
+
+        // Probe migration state - should be done since no docs in cold storage
+        var state = migrationService.probeAndSetState(MIGRATION_ID);
+        assertEquals("Migration should be in done state when no documents in cold storage", MIGRATION_DONE_STATE,
+                state);
+    }
+
+    @Test
+    public void testMigrationWithDeduplicatedBlobs() throws IOException {
+        // Create a blob with a specific digest
+        Blob blob1 = Blobs.createBlob(FILE_CONTENT);
+        blob1.setDigest("digest");
+
+        // Create first document with the blob
+        DocumentModel doc1 = session.createDocumentModel("/", "Doc1-" + UUID.randomUUID().toString().substring(0, 8),
+                "File");
+        doc1.setPropertyValue(FILE_CONTENT_PROPERTY, (Serializable) blob1);
+        doc1 = session.createDocument(doc1);
+        session.save();
+        transactionalFeature.nextTransaction();
+
+        // Create second document with the same blob (same digest)
+        DocumentModel doc2 = session.createDocumentModel("/", "Doc2-" + UUID.randomUUID().toString().substring(0, 8),
+                "File");
+        doc2.setPropertyValue(FILE_CONTENT_PROPERTY, doc1.getPropertyValue(FILE_CONTENT_PROPERTY));
+        doc2 = session.createDocument(doc2);
+        session.save();
+        transactionalFeature.nextTransaction();
+
+        // Move 1st document to cold storage manually (tests migration with same content digest)
+        doc1 = moveContentToColdStorage(session, doc1);
+        session.save();
+        transactionalFeature.nextTransaction();
+
+        // Verify both documents are now in cold storage
+        doc1 = session.getDocument(doc1.getRef());
+        doc2 = session.getDocument(doc2.getRef());
+        assertTrue("First document should have ColdStorage facet", doc1.hasFacet(COLD_STORAGE_FACET_NAME));
+        assertTrue("Second document should have ColdStorage facet", doc2.hasFacet(COLD_STORAGE_FACET_NAME));
+
+        // Both documents have the same cold storage blob
+        var coldContent1 = (ManagedBlob) doc1.getPropertyValue(COLD_STORAGE_CONTENT_PROPERTY);
+        var coldContent2 = (ManagedBlob) doc2.getPropertyValue(COLD_STORAGE_CONTENT_PROPERTY);
+        assertNotNull("First document should have cold storage content", coldContent1);
+        assertNotNull("Second document should have cold storage content", coldContent2);
+        assertEquals(coldContent1.getKey(), coldContent2.getKey());
+
+        // Restore first blob at provider level
+        var blobManager = Framework.getService(BlobManager.class);
+        var blobProvider1 = (MockS3BlobProvider) blobManager.getBlobProvider(coldContent1.getProviderId());
+        var key1 = ColdStorageServiceImpl.getContentBlobKey(coldContent1);
+        blobProvider1.updateBlob(new BlobUpdateContext(key1).withRestoreForDuration(Duration.ofDays(1)));
+
+        // Wait for the restores to complete
+        waitForRestore();
+        transactionalFeature.nextTransaction();
+
+        // Enable blocking property
+        Framework.getProperties().setProperty(COLD_STORAGE_RESTORE_MIGRATION_ENABLED_PROPERTY_NAME, "true");
+
+        // Probe migration state - should be enabled
+        var state = migrationService.probeAndSetState(MIGRATION_ID);
+        assertEquals("Migration should be in enabled state", MIGRATION_ENABLED_STATE, state);
+
+        // Run the migration
+        migrationService.runStep(MIGRATION_ID, MIGRATION_ENABLED_STATE + "-to-" + MIGRATION_DONE_STATE);
+
+        // Wait for migration to complete
+        await().atMost(Duration.ofMinutes(1)).until(() -> !migrationService.getStatus(MIGRATION_ID).isRunning());
+        transactionalFeature.nextTransaction();
+
+        // Verify both documents were restored
+        doc1 = session.getDocument(doc1.getRef());
+        doc2 = session.getDocument(doc2.getRef());
+        assertFalse("First document should not have ColdStorage facet after migration",
+                doc1.hasFacet(COLD_STORAGE_FACET_NAME));
+        assertFalse("Second document should not have ColdStorage facet after migration",
+                doc2.hasFacet(COLD_STORAGE_FACET_NAME));
+        assertNotNull("First document should have main content restored", doc1.getPropertyValue("file:content"));
+        assertNotNull("Second document should have main content restored", doc2.getPropertyValue("file:content"));
+
+        // Verify the restored content is correct
+        var restoredBlob1 = (Blob) doc1.getPropertyValue("file:content");
+        var restoredBlob2 = (Blob) doc2.getPropertyValue("file:content");
+        assertEquals("First document should have correct content", FILE_CONTENT, restoredBlob1.getString());
+        assertEquals("Second document should have correct content", FILE_CONTENT, restoredBlob2.getString());
+
+        // Probe state again - should be done since no documents remain in cold storage
+        state = migrationService.probeAndSetState(MIGRATION_ID);
+        assertEquals("Migration should be in done state after successful restore", MIGRATION_DONE_STATE, state);
+    }
+
+    @Test
+    public void testMigrationWithMixedDownloadableBlobs() {
+        // Create 10 documents in cold storage
+        var docs = new java.util.ArrayList<DocumentModel>();
+        for (int i = 0; i < 10; i++) {
+            var doc = createFileDocument(session);
+            session.save();
+            transactionalFeature.nextTransaction();
+
+            doc = moveContentToColdStorage(session, doc);
+            session.save();
+            transactionalFeature.nextTransaction();
+
+            doc = session.getDocument(doc.getRef());
+            checkMoveContent(doc);
+            assertTrue("Document should have ColdStorage facet", doc.hasFacet(COLD_STORAGE_FACET_NAME));
+            docs.add(doc);
+        }
+
+        // Restore only 6 out of 10 documents (leave 4 non-downloadable)
+        var blobManager = Framework.getService(BlobManager.class);
+        for (int i = 0; i < 6; i++) {
+            var doc = docs.get(i);
+            var coldContent = (ManagedBlob) doc.getPropertyValue(COLD_STORAGE_CONTENT_PROPERTY);
+            var blobProvider = (MockS3BlobProvider) blobManager.getBlobProvider(coldContent.getProviderId());
+            var key = ColdStorageServiceImpl.getContentBlobKey(coldContent);
+            var updateContext = new BlobUpdateContext(key).withRestoreForDuration(Duration.ofDays(1));
+            blobProvider.updateBlob(updateContext);
+        }
+
+        // Wait for the 6 restores to complete
+        waitForRestore();
+        transactionalFeature.nextTransaction();
+
+        // Enable blocking property
+        Framework.getProperties().setProperty(COLD_STORAGE_RESTORE_MIGRATION_ENABLED_PROPERTY_NAME, "true");
+
+        // Probe migration state - should be enabled
+        var state = migrationService.probeAndSetState(MIGRATION_ID);
+        assertEquals("Migration should be in enabled state", MIGRATION_ENABLED_STATE, state);
+
+        // Run the migration
+        migrationService.runStep(MIGRATION_ID, MIGRATION_ENABLED_STATE + "-to-" + MIGRATION_DONE_STATE);
+
+        // Wait for migration to complete
+        await().atMost(Duration.ofMinutes(1)).until(() -> !migrationService.getStatus(MIGRATION_ID).isRunning());
+        transactionalFeature.nextTransaction();
+
+        // Verify results:
+        // - 6 documents should be restored (no ColdStorage facet)
+        // - 4 documents should still be in cold storage (still have facet)
+        int restoredCount = 0;
+        int stillInColdStorageCount = 0;
+
+        for (DocumentModel doc : docs) {
+            doc = session.getDocument(doc.getRef());
+            if (doc.hasFacet(COLD_STORAGE_FACET_NAME)) {
+                stillInColdStorageCount++;
+            } else {
+                restoredCount++;
+                assertNotNull("Restored document should have main content", doc.getPropertyValue("file:content"));
+            }
+        }
+
+        assertEquals("Should have restored 6 documents", 6, restoredCount);
+        assertEquals("Should have 4 documents still in cold storage", 4, stillInColdStorageCount);
+
+        // Probe state again - should still be enabled (not done) because 4 documents remain
+        state = migrationService.probeAndSetState(MIGRATION_ID);
+        assertEquals("Migration should remain in enabled state when some documents cannot be restored",
+                MIGRATION_ENABLED_STATE, state);
+    }
+
+    // Helper methods
+
+    protected DocumentModel createFileDocument(CoreSession session) {
+        String uniqueName = "MyFile-" + UUID.randomUUID().toString().substring(0, 8);
+        DocumentModel documentModel = session.createDocumentModel("/", uniqueName, "File");
+        Blob blob = Blobs.createBlob(FILE_CONTENT);
+        blob.setDigest(UUID.randomUUID().toString());
+        documentModel.setPropertyValue(FILE_CONTENT_PROPERTY, (Serializable) blob);
+        return session.createDocument(documentModel);
+    }
+
+    protected DocumentModel moveContentToColdStorage(CoreSession session, DocumentModel documentModel) {
+        documentModel = coldStorageService.moveToColdStorage(session, documentModel.getRef());
+        checkMoveContent(documentModel);
+        return documentModel;
+    }
+
+    protected void checkMoveContent(DocumentModel doc) {
+        // check document
+        assertTrue(doc.hasFacet(COLD_STORAGE_FACET_NAME));
+
+        // check blob
+        Blob coldStorageContent = (Blob) doc.getPropertyValue(COLD_STORAGE_CONTENT_PROPERTY);
+        assertNotNull(coldStorageContent);
+        assertTrue(ColdStorageHelper.isInColdStorage((ManagedBlob) coldStorageContent));
+    }
+}

--- a/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/operations/RestoreFromColdStorageTest.java
+++ b/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/operations/RestoreFromColdStorageTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.nuxeo.coldstorage.ColdStorageConstants.COLD_STORAGE_CHECK_CONTENT_AVAILABILITY_EVENT_NAME;
+import static org.nuxeo.coldstorage.MockS3BlobProvider.waitForRestore;
 
 import java.io.IOException;
 import java.util.List;
@@ -37,7 +38,6 @@ import org.nuxeo.coldstorage.ColdStorageConstants;
 import org.nuxeo.coldstorage.DummyColdStorageFeature;
 import org.nuxeo.ecm.automation.OperationContext;
 import org.nuxeo.ecm.automation.OperationException;
-import org.nuxeo.ecm.core.DummyBlobProvider;
 import org.nuxeo.ecm.core.api.Blob;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.NuxeoException;
@@ -55,7 +55,7 @@ public class RestoreFromColdStorageTest extends AbstractTestColdStorageOperation
     protected NotificationManager notificationManager;
 
     @Test
-    public void shouldBeRestore() throws IOException, OperationException, InterruptedException {
+    public void shouldBeRestore() throws IOException, OperationException {
         DocumentModel documentModel = createFileDocument(session, true);
         // first make the move to cold storage
         documentModel = moveContentToColdStorage(session, documentModel);
@@ -63,7 +63,7 @@ public class RestoreFromColdStorageTest extends AbstractTestColdStorageOperation
     }
 
     @Test
-    public void shouldFailBeingRestored() throws IOException, OperationException, InterruptedException {
+    public void shouldFailBeingRestored() throws IOException, OperationException {
         DocumentModel documentModel = createFileDocument(session, true);
         transactionalFeature.nextTransaction();
 
@@ -81,7 +81,7 @@ public class RestoreFromColdStorageTest extends AbstractTestColdStorageOperation
     }
 
     @Test
-    public void shouldFailRestoreNoColdStorageContent() throws OperationException, IOException, InterruptedException {
+    public void shouldFailRestoreNoColdStorageContent() throws OperationException, IOException {
         DocumentModel documentModel = createFileDocument(session, true);
         try {
             // request a restore from the cold storage
@@ -93,7 +93,7 @@ public class RestoreFromColdStorageTest extends AbstractTestColdStorageOperation
     }
 
     @Test
-    public void shouldMakeRestoreMultipleTimes() throws IOException, OperationException, InterruptedException {
+    public void shouldMakeRestoreMultipleTimes() throws IOException, OperationException {
         DocumentModel documentModel = createFileDocument(session, true);
         transactionalFeature.nextTransaction();
 
@@ -127,8 +127,7 @@ public class RestoreFromColdStorageTest extends AbstractTestColdStorageOperation
         }
     }
 
-    protected DocumentModel restoreContentFromColdStorage(DocumentModel documentModel)
-            throws OperationException, IOException, InterruptedException {
+    protected void restoreContentFromColdStorage(DocumentModel documentModel) throws OperationException, IOException {
         try (OperationContext context = new OperationContext(session)) {
             context.setInput(documentModel);
             documentModel = (DocumentModel) automationService.run(context, RestoreFromColdStorage.ID);
@@ -144,11 +143,10 @@ public class RestoreFromColdStorageTest extends AbstractTestColdStorageOperation
         List<String> subscriptions = notificationManager.getSubscriptionsForUserOnDocument(username, documentModel);
         assertTrue(subscriptions.contains(ColdStorageConstants.COLD_STORAGE_CONTENT_RESTORED_NOTIFICATION_NAME));
         assertFalse(subscriptions.contains(ColdStorageConstants.COLD_STORAGE_CONTENT_AVAILABLE_NOTIFICATION_NAME));
-        return documentModel;
     }
 
-    protected void waitForRetrieve() throws InterruptedException {
-        Thread.sleep(DummyBlobProvider.RESTORE_DELAY_MILLISECONDS + 200);
+    protected void waitForRetrieve() {
+        waitForRestore();
         EventService eventService = Framework.getService(EventService.class);
         EventContextImpl ctx = new EventContextImpl();
         eventService.fireEvent(ctx.newEvent(COLD_STORAGE_CHECK_CONTENT_AVAILABILITY_EVENT_NAME));

--- a/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/service/AbstractTestColdStorageService.java
+++ b/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/service/AbstractTestColdStorageService.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
@@ -32,6 +33,7 @@ import static org.nuxeo.coldstorage.ColdStorageConstants.COLD_STORAGE_BEING_RETR
 import static org.nuxeo.coldstorage.ColdStorageConstants.COLD_STORAGE_CONTENT_DOWNLOADABLE_UNTIL;
 import static org.nuxeo.coldstorage.ColdStorageConstants.COLD_STORAGE_CONTENT_PROPERTY;
 import static org.nuxeo.coldstorage.ColdStorageConstants.COLD_STORAGE_FACET_NAME;
+import static org.nuxeo.coldstorage.ColdStorageConstants.COLD_STORAGE_RESTORE_MIGRATION_ENABLED_PROPERTY_NAME;
 import static org.nuxeo.coldstorage.ColdStorageConstants.COLD_STORAGE_TO_BE_RESTORED_PROPERTY;
 import static org.nuxeo.coldstorage.ColdStorageConstants.FILE_CONTENT_PROPERTY;
 import static org.nuxeo.coldstorage.events.PreventColdStorageUpdateListener.DISABLE_PREVENT_COLD_STORAGE_UPDATE_LISTENER;
@@ -75,6 +77,7 @@ import org.nuxeo.ecm.core.test.StorageConfiguration;
 import org.nuxeo.runtime.test.runner.Deploy;
 import org.nuxeo.runtime.test.runner.FeaturesRunner;
 import org.nuxeo.runtime.test.runner.TransactionalFeature;
+import org.nuxeo.runtime.test.runner.WithFrameworkProperty;
 
 /**
  * @since 2021.0.0
@@ -366,6 +369,16 @@ public abstract class AbstractTestColdStorageService {
         // Assert binary text has not been erased after doc sent to cold storage
         res = session.query(String.format("SELECT * FROM Document WHERE ecm:fulltext = '%s'", fileContent));
         assertEquals(1, res.size());
+    }
+
+    @Test
+    @WithFrameworkProperty(name = COLD_STORAGE_RESTORE_MIGRATION_ENABLED_PROPERTY_NAME, value = "true")
+    public void shouldFailWhenMoveToColdStorageIsBlocked() {
+        DocumentRef docRef = createFileDocument(DEFAULT_DOC_NAME, true);
+
+        var e = assertThrows(NuxeoException.class, () -> service.moveToColdStorage(session, docRef));
+        assertEquals(SC_FORBIDDEN, e.getStatusCode());
+        assertTrue(e.getMessage().contains("Move to cold storage operations are currently blocked"));
     }
 
     protected void moveAndRestore(DocumentRef docRef) throws IOException {

--- a/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/service/AbstractTestColdStorageService.java
+++ b/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/service/AbstractTestColdStorageService.java
@@ -297,8 +297,7 @@ public abstract class AbstractTestColdStorageService {
         }
     }
 
-    protected DocumentModel assertRestoredFromColdStorage(DocumentRef documentRef, String expectedContent)
-            throws IOException {
+    protected void assertRestoredFromColdStorage(DocumentRef documentRef, String expectedContent) throws IOException {
         DocumentModel documentModel = session.getDocument(documentRef);
         // we shouldn't have any ColdStorage content
         assertFalse(documentModel.hasFacet(COLD_STORAGE_FACET_NAME));
@@ -308,7 +307,6 @@ public abstract class AbstractTestColdStorageService {
         BlobStatus status = getStatus(fileContent);
         assertFalse(status.isOngoingRestore());
         assertTrue(status.isDownloadable());
-        return documentModel;
     }
 
     @Test
@@ -370,11 +368,11 @@ public abstract class AbstractTestColdStorageService {
         assertEquals(1, res.size());
     }
 
-    protected DocumentModel moveAndRestore(DocumentRef docRef) throws IOException {
+    protected void moveAndRestore(DocumentRef docRef) throws IOException {
         // move the blob to cold storage and verify the content
         moveAndVerifyContent(session, docRef);
         // undo move from the cold storage
-        return service.restoreFromColdStorage(session, docRef);
+        service.restoreFromColdStorage(session, docRef);
     }
 
     protected DocumentModel moveAndVerifyContent(CoreSession session, DocumentRef ref) throws IOException {
@@ -429,17 +427,17 @@ public abstract class AbstractTestColdStorageService {
         return document.getRef();
     }
 
-    protected List<DocumentModel> createSameBlobFileDocuments(String name, int nbDoc, Blob blob, String username,
-            String... permissions) {
+    protected List<DocumentModel> createSameBlobFileDocuments(String name, Blob blob) {
         List<DocumentModel> docs = new ArrayList<>();
-        for (int i = 0; i < nbDoc; i++) {
+        for (int i = 0; i < 10; i++) {
             DocumentModel documentModel = session.createDocumentModel("/", name + (i + 1), "File");
             documentModel.setPropertyValue("file:content", (Serializable) blob);
             DocumentModel document = session.createDocument(documentModel);
             ACP acp = document.getACP();
             ACL acl = acp.getOrCreateACL();
-            for (String permission : permissions) {
-                acl.add(new ACE(username, permission, true));
+            for (String permission : new String[] { SecurityConstants.READ, SecurityConstants.WRITE,
+                    SecurityConstants.WRITE_COLD_STORAGE }) {
+                acl.add(new ACE("john", permission, true));
             }
             session.setACP(document.getRef(), acp, false);
             docs.add(document);

--- a/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/service/TestDummyColdStorageService.java
+++ b/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/service/TestDummyColdStorageService.java
@@ -33,6 +33,7 @@ import static org.nuxeo.coldstorage.ColdStorageConstants.COLD_STORAGE_CONTENT_DO
 import static org.nuxeo.coldstorage.ColdStorageConstants.COLD_STORAGE_CONTENT_PROPERTY;
 import static org.nuxeo.coldstorage.ColdStorageConstants.FILE_CONTENT_PROPERTY;
 import static org.nuxeo.coldstorage.ColdStorageConstants.GET_DOCUMENTS_TO_CHECK_QUERY;
+import static org.nuxeo.coldstorage.MockS3BlobProvider.waitForRestore;
 import static org.nuxeo.ecm.core.api.versioning.VersioningService.VERSIONING_OPTION;
 
 import java.io.IOException;
@@ -56,8 +57,8 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.junit.Test;
 import org.nuxeo.coldstorage.ColdStorageHelper;
 import org.nuxeo.coldstorage.DummyColdStorageFeature;
+import org.nuxeo.coldstorage.MockS3BlobProvider;
 import org.nuxeo.coldstorage.action.MoveToColdStorageContentAction;
-import org.nuxeo.ecm.core.DummyBlobProvider;
 import org.nuxeo.ecm.core.api.Blob;
 import org.nuxeo.ecm.core.api.Blobs;
 import org.nuxeo.ecm.core.api.CoreInstance;
@@ -167,7 +168,7 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
     @Test
     @Deploy("org.nuxeo.coldstorage.test:OSGI-INF/test-coldstorage-bulk-contrib.xml")
     @LogCaptureFeature.FilterWith(ColdStorageActionsLogFilter.class)
-    public void shouldMoveManyDocsWithSameBlobToColdStorage() throws IOException, InterruptedException {
+    public void shouldMoveManyDocsWithSameBlobToColdStorage() throws IOException {
         // with regular user with "WriteColdStorage" permission
         // Let's create 2 lists of documents all sharing the same blob
         final String fileContent = FILE_CONTENT + System.currentTimeMillis();
@@ -223,7 +224,7 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
     }
 
     @Test
-    public void shouldMoveToColdStorageAfterRestore() throws IOException, InterruptedException {
+    public void shouldMoveToColdStorageAfterRestore() throws IOException {
         // with regular user with "WriteColdStorage" permission
         final String blobContent = FILE_CONTENT + System.currentTimeMillis();
         ACE[] aces = { new ACE("john", SecurityConstants.READ, true), //
@@ -239,7 +240,7 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
     }
 
     @Test
-    public void shouldCheckAvailability() throws InterruptedException, IOException {
+    public void shouldCheckAvailability() throws IOException {
         // Create 3 docs on which retrieval was requested
         DocumentRef docRef1 = moveAndRequestRetrievalFromColdStorage(DEFAULT_DOC_NAME + "1").getRef();
         DocumentRef docRef2 = moveAndRequestRetrievalFromColdStorage(DEFAULT_DOC_NAME + "2").getRef();
@@ -249,8 +250,8 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
         List<DocumentModel> beingRetrievedDocs = session.query(GET_DOCUMENTS_TO_CHECK_QUERY);
         assertEquals(3, beingRetrievedDocs.size());
 
-        Thread.sleep(DummyBlobProvider.RESTORE_DELAY_MILLISECONDS + 200);
-        // Tweek blob status to have a doc on which retrieval was requested and that is still being retrieved
+        waitForRestore();
+        // Tweak blob status to have a doc on which retrieval was requested and that is still being retrieved
         BlobStatus coldContentStatusOfFile2 = new BlobStatus().withDownloadable(false).withOngoingRestore(true);
         addColdStorageContentBlobStatus(docRef2, coldContentStatusOfFile2);
         // and another one on which retrieval was requested but is no longer retrieved because retrieval time expired
@@ -296,7 +297,7 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
 
     // NXP-32003
     @Test
-    public void shouldCheckAvailabilityOnVersion() throws InterruptedException {
+    public void shouldCheckAvailabilityOnVersion() {
         DocumentModel documentModel = session.createDocumentModel("/", "DocWithVersion", "File");
         String content = FILE_CONTENT + System.currentTimeMillis();
         Blob blob = Blobs.createBlob(content);
@@ -313,12 +314,12 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
         // Retrieve the version
         version = service.retrieveFromColdStorage(session, version.getRef(), RESTORE_DURATION);
         transactionalFeature.nextTransaction();
-        Thread.sleep(DummyBlobProvider.RESTORE_DELAY_MILLISECONDS + 200);
+        waitForRestore();
         assertTrue(service.checkIsRetrieved(session, version));
     }
 
     @Test
-    public void shouldMakeRestoreImmediately() throws IOException, InterruptedException {
+    public void shouldMakeRestoreImmediately() throws IOException {
         final String fileContent = FILE_CONTENT + System.currentTimeMillis();
         DocumentRef docRef = createFileDocument(DEFAULT_DOC_NAME, fileContent);
         moveAndRestore(docRef);
@@ -328,7 +329,7 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
 
     @Test
     @Deploy("org.nuxeo.coldstorage.test:OSGI-INF/test-thumbnail-recomputation-contrib.xml")
-    public void shouldNotRecomputeThumbnailOnMoveAndRestore() throws IOException, InterruptedException {
+    public void shouldNotRecomputeThumbnailOnMoveAndRestore() throws IOException {
         final String fileContent = FILE_CONTENT + System.currentTimeMillis();
         DocumentModel documentModel = session.createDocumentModel("/", DEFAULT_DOC_NAME, "MyCustomFile");
         documentModel.setPropertyValue("file:content", (Serializable) Blobs.createBlob(fileContent));
@@ -389,7 +390,7 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
 
         // Let's mock a document sent to ColdStorage but somehow its blob has been restored independently
         ManagedBlob coldContent = (ManagedBlob) documentModel.getPropertyValue(COLD_STORAGE_CONTENT_PROPERTY);
-        DummyBlobProvider blobProvider = (DummyBlobProvider) blobManager.getBlobProvider(coldContent.getProviderId());
+        MockS3BlobProvider blobProvider = (MockS3BlobProvider) blobManager.getBlobProvider(coldContent.getProviderId());
         String key = ColdStorageServiceImpl.getContentBlobKey(coldContent);
         BlobUpdateContext updateContext = new BlobUpdateContext(key).withColdStorageClass(false);
         blobProvider.updateBlob(updateContext);
@@ -412,7 +413,7 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
 
         // Let's mock a document sent to ColdStorage but somehow its blob has been restored independently
         ManagedBlob coldContent = (ManagedBlob) documentModel.getPropertyValue(COLD_STORAGE_CONTENT_PROPERTY);
-        DummyBlobProvider blobProvider = (DummyBlobProvider) blobManager.getBlobProvider(coldContent.getProviderId());
+        MockS3BlobProvider blobProvider = (MockS3BlobProvider) blobManager.getBlobProvider(coldContent.getProviderId());
         String key = ColdStorageServiceImpl.getContentBlobKey(coldContent);
         BlobUpdateContext updateContext = new BlobUpdateContext(key).withColdStorageClass(false);
         blobProvider.updateBlob(updateContext);
@@ -424,7 +425,7 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
 
     // NXP-31865
     @Test
-    public void shouldMoveAndRestoreVersionsWithSameColdStorageContent() throws InterruptedException, IOException {
+    public void shouldMoveAndRestoreVersionsWithSameColdStorageContent() throws IOException {
         DocumentModel documentModel = session.createDocumentModel("/", "FileWithVersions", "File");
         String content = FILE_CONTENT + System.currentTimeMillis();
         Blob blob = Blobs.createBlob(content);
@@ -457,8 +458,8 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
         assertRestoredFromColdStorage(version.getRef(), content);
     }
 
-    protected void waitForRetrieve() throws InterruptedException {
-        Thread.sleep(DummyBlobProvider.RESTORE_DELAY_MILLISECONDS + 200);
+    protected void waitForRetrieve() {
+        waitForRestore();
         EventContextImpl ctx = new EventContextImpl();
         Framework.getService(EventService.class)
                  .fireEvent(ctx.newEvent(COLD_STORAGE_CHECK_CONTENT_AVAILABILITY_EVENT_NAME));
@@ -469,7 +470,7 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
         ManagedBlob coldContent = (ManagedBlob) session.getDocument(documentRef)
                                                        .getPropertyValue(COLD_STORAGE_CONTENT_PROPERTY);
 
-        DummyBlobProvider blobProvider = (DummyBlobProvider) blobManager.getBlobProvider(coldContent.getProviderId());
+        MockS3BlobProvider blobProvider = (MockS3BlobProvider) blobManager.getBlobProvider(coldContent.getProviderId());
         blobProvider.addStatus(coldContent, blobStatus);
     }
 

--- a/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/service/TestDummyColdStorageService.java
+++ b/nuxeo-coldstorage/src/test/java/org/nuxeo/coldstorage/service/TestDummyColdStorageService.java
@@ -33,9 +33,6 @@ import static org.nuxeo.coldstorage.ColdStorageConstants.COLD_STORAGE_CONTENT_DO
 import static org.nuxeo.coldstorage.ColdStorageConstants.COLD_STORAGE_CONTENT_PROPERTY;
 import static org.nuxeo.coldstorage.ColdStorageConstants.FILE_CONTENT_PROPERTY;
 import static org.nuxeo.coldstorage.ColdStorageConstants.GET_DOCUMENTS_TO_CHECK_QUERY;
-import static org.nuxeo.ecm.core.api.security.SecurityConstants.READ;
-import static org.nuxeo.ecm.core.api.security.SecurityConstants.WRITE;
-import static org.nuxeo.ecm.core.api.security.SecurityConstants.WRITE_COLD_STORAGE;
 import static org.nuxeo.ecm.core.api.versioning.VersioningService.VERSIONING_OPTION;
 
 import java.io.IOException;
@@ -49,7 +46,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
@@ -130,7 +126,7 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
         assertEquals(1, caughtEvents.size());
         assertEquals(String.format(
                 "Cannot move document %s to cold storage: The document %s is under retention or legal hold and cannot be moved to cold storage",
-                legalHoldRef, legalHoldRef), caughtEvents.get(0));
+                legalHoldRef, legalHoldRef), caughtEvents.getFirst());
 
         BulkStatus status = bulkService.getStatus(commandId);
         assertTrue(status.isCompleted());
@@ -179,19 +175,16 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
         blob1.setDigest(UUID.randomUUID().toString());
         Blob blob2 = Blobs.createBlob(fileContent + fileContent);
         blob2.setDigest(UUID.randomUUID().toString());
-        List<DocumentModel> list1 = createSameBlobFileDocuments(DEFAULT_DOC_NAME + "1", 10, blob1, "john", READ, WRITE,
-                WRITE_COLD_STORAGE);
+        List<DocumentModel> list1 = createSameBlobFileDocuments(DEFAULT_DOC_NAME + "1", blob1);
         // and another one with a different blob
-        List<DocumentModel> list2 = createSameBlobFileDocuments(DEFAULT_DOC_NAME + "2", 10, blob2, "john", READ, WRITE,
-                WRITE_COLD_STORAGE);
+        List<DocumentModel> list2 = createSameBlobFileDocuments(DEFAULT_DOC_NAME + "2", blob2);
         coreFeature.waitForAsyncCompletion(); // for thumbnail generation
-        List<DocumentModel> documentModels = new ArrayList<>();
-        documentModels = Stream.concat(list1.stream(), list2.stream()).collect(Collectors.toList());
-        CoreSession userSession = CoreInstance.getCoreSession(documentModels.get(0).getRepositoryName(), "john");
+        List<DocumentModel> documentModels = Stream.concat(list1.stream(), list2.stream()).toList();
+        CoreSession userSession = CoreInstance.getCoreSession(documentModels.getFirst().getRepositoryName(), "john");
 
         // Move only the 2 first doc
-        service.moveToColdStorage(userSession, list1.get(0).getRef());
-        service.moveToColdStorage(userSession, list2.get(0).getRef());
+        service.moveToColdStorage(userSession, list1.getFirst().getRef());
+        service.moveToColdStorage(userSession, list2.getFirst().getRef());
         coreFeature.waitForAsyncCompletion();
 
         // Moving the 2 first document to cold storage should moved all the other ones
@@ -203,8 +196,8 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
         }
 
         // Restore only the 2 first doc
-        service.restoreFromColdStorage(session, list1.get(0).getRef());
-        service.restoreFromColdStorage(session, list2.get(0).getRef());
+        service.restoreFromColdStorage(session, list1.getFirst().getRef());
+        service.restoreFromColdStorage(session, list2.getFirst().getRef());
         waitForRetrieve();
 
         // Restoring the first document to cold storage should restore all the other ones
@@ -273,7 +266,7 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
 
             beingRetrievedDocs = session.query(GET_DOCUMENTS_TO_CHECK_QUERY);
             assertEquals(1, beingRetrievedDocs.size());
-            assertEquals(docRef2, beingRetrievedDocs.get(0).getRef());
+            assertEquals(docRef2, beingRetrievedDocs.getFirst().getRef());
 
             DocumentModel doc1 = session.getDocument(docRef1);
             String serverUrl = NotificationServiceHelper.getNotificationService().getServerUrlPrefix();
@@ -315,7 +308,7 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
         transactionalFeature.nextTransaction();
         documentModel = service.moveToColdStorage(session, documentModel.getRef());
         transactionalFeature.nextTransaction();
-        DocumentModel version = session.getVersions(documentModel.getRef()).get(0);
+        DocumentModel version = session.getVersions(documentModel.getRef()).getFirst();
 
         // Retrieve the version
         version = service.retrieveFromColdStorage(session, version.getRef(), RESTORE_DURATION);
@@ -443,7 +436,7 @@ public class TestDummyColdStorageService extends AbstractTestColdStorageService 
 
         List<DocumentModel> versions = session.getVersions(documentModel.getRef());
         assertEquals(1, versions.size());
-        DocumentModel version = versions.get(0);
+        DocumentModel version = versions.getFirst();
 
         transactionalFeature.nextTransaction();
 


### PR DESCRIPTION
## Summary

Adds migration to exit the cold storage addon by restoring all documents and blocking move operations.

## Changes

- **Migration**: `restore-from-cold-storage-migration` with states: disabled → enabled → done
- **Property**: `nuxeo.coldstorage.migration.restore.enabled` blocks move to cold storage when enabled
- **Resilience**: Gracefully skips non-downloadable blobs with WARNING, keeps ColdStorage facet
- **Frontend**: UI buttons automatically hidden when migration enabled
- **Tests**: 6 migration tests including mixed batch scenario + 1 blocking test
- **Documentation**: Complete operational guide in README.md with S3 Batch Operations workflow

## Operational Workflow

1. Enable property to block new moves
2. Restore S3 objects via S3 Batch Operations (Bulk tier, 30-day window recommended)
3. Run migration via REST API
4. Verify state is `done` (all documents restored)
5. Uninstall addon

Assumes S3 objects are in downloadable state before running migration.